### PR TITLE
#129 + #96: populate EU transposition mapping + transposition deadlines (SPARQL GET→POST fix)

### DIFF
--- a/krr_outputs/alkoholi_tubaka_kutuse_ja_elektriaktsiisi_seadus_peep.json
+++ b/krr_outputs/alkoholi_tubaka_kutuse_ja_elektriaktsiisi_seadus_peep.json
@@ -161,7 +161,16 @@
         {
           "@id": "http://eurovoc.europa.eu/5611"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32010L0012"
+        },
+        {
+          "@id": "estleg:EU_32009L0028"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_ATKE",

--- a/krr_outputs/ariseadustik1_peep.json
+++ b/krr_outputs/ariseadustik1_peep.json
@@ -36,7 +36,16 @@
         {
           "@id": "http://eurovoc.europa.eu/5231"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32007L0036"
+        },
+        {
+          "@id": "estleg:EU_32009L0109"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_riseadustik1",

--- a/krr_outputs/asjaoigusseadus_osa10_peep.json
+++ b/krr_outputs/asjaoigusseadus_osa10_peep.json
@@ -42,7 +42,13 @@
         {
           "@id": "http://eurovoc.europa.eu/2431"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32009L0044"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_AOS_osa10",

--- a/krr_outputs/asjaoigusseadus_osa11_peep.json
+++ b/krr_outputs/asjaoigusseadus_osa11_peep.json
@@ -41,7 +41,13 @@
         {
           "@id": "http://eurovoc.europa.eu/2431"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32009L0044"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_AOS_osa11",

--- a/krr_outputs/asjaoigusseadus_osa1_peep.json
+++ b/krr_outputs/asjaoigusseadus_osa1_peep.json
@@ -49,7 +49,13 @@
         {
           "@id": "http://eurovoc.europa.eu/2451"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32009L0044"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_AOS_osa1",

--- a/krr_outputs/asjaoigusseadus_osa2_peep.json
+++ b/krr_outputs/asjaoigusseadus_osa2_peep.json
@@ -43,7 +43,13 @@
         {
           "@id": "http://eurovoc.europa.eu/2451"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32009L0044"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_AOS_osa2",

--- a/krr_outputs/asjaoigusseadus_osa3_peep.json
+++ b/krr_outputs/asjaoigusseadus_osa3_peep.json
@@ -46,7 +46,13 @@
         {
           "@id": "http://eurovoc.europa.eu/6016"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32009L0044"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_AOS_osa3",

--- a/krr_outputs/asjaoigusseadus_osa4_peep.json
+++ b/krr_outputs/asjaoigusseadus_osa4_peep.json
@@ -37,7 +37,13 @@
         {
           "@id": "http://eurovoc.europa.eu/2431"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32009L0044"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_AOS_osa4",

--- a/krr_outputs/asjaoigusseadus_osa5_peep.json
+++ b/krr_outputs/asjaoigusseadus_osa5_peep.json
@@ -40,7 +40,13 @@
         {
           "@id": "http://eurovoc.europa.eu/2431"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32009L0044"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_AOS_osa5",

--- a/krr_outputs/asjaoigusseadus_osa6-13_peep.json
+++ b/krr_outputs/asjaoigusseadus_osa6-13_peep.json
@@ -48,7 +48,13 @@
         {
           "@id": "http://eurovoc.europa.eu/2451"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32009L0044"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_AOS_osa6_13",

--- a/krr_outputs/asjaoigusseadus_osa7_peep.json
+++ b/krr_outputs/asjaoigusseadus_osa7_peep.json
@@ -40,7 +40,13 @@
         {
           "@id": "http://eurovoc.europa.eu/6016"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32009L0044"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_AOS_osa7",

--- a/krr_outputs/asjaoigusseadus_osa8_peep.json
+++ b/krr_outputs/asjaoigusseadus_osa8_peep.json
@@ -45,7 +45,13 @@
         {
           "@id": "http://eurovoc.europa.eu/5241"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32009L0044"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_AOS_osa8",

--- a/krr_outputs/asjaoigusseadus_osa9_peep.json
+++ b/krr_outputs/asjaoigusseadus_osa9_peep.json
@@ -68,7 +68,13 @@
         {
           "@id": "http://eurovoc.europa.eu/2431"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32009L0044"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_AOS_osa9",

--- a/krr_outputs/asjaoigusseaduse_rakendamise_seadus_peep.json
+++ b/krr_outputs/asjaoigusseaduse_rakendamise_seadus_peep.json
@@ -46,7 +46,13 @@
         {
           "@id": "http://eurovoc.europa.eu/2431"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32009L0044"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_AÕSRS",

--- a/krr_outputs/audiitortegevuse_seadus_peep.json
+++ b/krr_outputs/audiitortegevuse_seadus_peep.json
@@ -112,7 +112,13 @@
         {
           "@id": "http://eurovoc.europa.eu/2446"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32006L0043"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_AUDIIT",

--- a/krr_outputs/avaliku_teabe_seadus_peep.json
+++ b/krr_outputs/avaliku_teabe_seadus_peep.json
@@ -722,7 +722,19 @@
         {
           "@id": "http://eurovoc.europa.eu/6006"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32003L0098"
+        },
+        {
+          "@id": "estleg:EU_32007L0002"
+        },
+        {
+          "@id": "estleg:EU_32009L0071"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_AVTS",

--- a/krr_outputs/biotsiidiseadus_peep.json
+++ b/krr_outputs/biotsiidiseadus_peep.json
@@ -58,7 +58,235 @@
         {
           "@id": "http://eurovoc.europa.eu/2836"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32013L0044"
+        },
+        {
+          "@id": "estleg:EU_32011L0081"
+        },
+        {
+          "@id": "estleg:EU_32011L0071"
+        },
+        {
+          "@id": "estleg:EU_32012L0003"
+        },
+        {
+          "@id": "estleg:EU_32013L0005"
+        },
+        {
+          "@id": "estleg:EU_32012L0043"
+        },
+        {
+          "@id": "estleg:EU_32012L0041"
+        },
+        {
+          "@id": "estleg:EU_32013L0006"
+        },
+        {
+          "@id": "estleg:EU_32013L0003"
+        },
+        {
+          "@id": "estleg:EU_32012L0038"
+        },
+        {
+          "@id": "estleg:EU_32013L0004"
+        },
+        {
+          "@id": "estleg:EU_32012L0042"
+        },
+        {
+          "@id": "estleg:EU_32012L0040"
+        },
+        {
+          "@id": "estleg:EU_32012L0015"
+        },
+        {
+          "@id": "estleg:EU_32011L0078"
+        },
+        {
+          "@id": "estleg:EU_32013L0041"
+        },
+        {
+          "@id": "estleg:EU_32013L0007"
+        },
+        {
+          "@id": "estleg:EU_32012L0002"
+        },
+        {
+          "@id": "estleg:EU_32012L0016"
+        },
+        {
+          "@id": "estleg:EU_32012L0022"
+        },
+        {
+          "@id": "estleg:EU_32012L0020"
+        },
+        {
+          "@id": "estleg:EU_32011L0080"
+        },
+        {
+          "@id": "estleg:EU_32012L0014"
+        },
+        {
+          "@id": "estleg:EU_32011L0067"
+        },
+        {
+          "@id": "estleg:EU_32011L0066"
+        },
+        {
+          "@id": "estleg:EU_32011L0079"
+        },
+        {
+          "@id": "estleg:EU_32011L0069"
+        },
+        {
+          "@id": "estleg:EU_32011L0011"
+        },
+        {
+          "@id": "estleg:EU_32011L0012"
+        },
+        {
+          "@id": "estleg:EU_32011L0010"
+        },
+        {
+          "@id": "estleg:EU_32011L0013"
+        },
+        {
+          "@id": "estleg:EU_32009L0107"
+        },
+        {
+          "@id": "estleg:EU_32010L0009"
+        },
+        {
+          "@id": "estleg:EU_32010L0007"
+        },
+        {
+          "@id": "estleg:EU_32010L0011"
+        },
+        {
+          "@id": "estleg:EU_32010L0008"
+        },
+        {
+          "@id": "estleg:EU_32010L0005"
+        },
+        {
+          "@id": "estleg:EU_32010L0010"
+        },
+        {
+          "@id": "estleg:EU_32009L0151"
+        },
+        {
+          "@id": "estleg:EU_32009L0150"
+        },
+        {
+          "@id": "estleg:EU_32009L0098"
+        },
+        {
+          "@id": "estleg:EU_32009L0099"
+        },
+        {
+          "@id": "estleg:EU_32009L0094"
+        },
+        {
+          "@id": "estleg:EU_32009L0096"
+        },
+        {
+          "@id": "estleg:EU_32009L0093"
+        },
+        {
+          "@id": "estleg:EU_32009L0095"
+        },
+        {
+          "@id": "estleg:EU_32009L0084"
+        },
+        {
+          "@id": "estleg:EU_32009L0091"
+        },
+        {
+          "@id": "estleg:EU_32010L0071"
+        },
+        {
+          "@id": "estleg:EU_32010L0050"
+        },
+        {
+          "@id": "estleg:EU_32010L0051"
+        },
+        {
+          "@id": "estleg:EU_32010L0074"
+        },
+        {
+          "@id": "estleg:EU_32010L0072"
+        },
+        {
+          "@id": "estleg:EU_32008L0086"
+        },
+        {
+          "@id": "estleg:EU_32007L0069"
+        },
+        {
+          "@id": "estleg:EU_32006L0050"
+        },
+        {
+          "@id": "estleg:EU_32008L0085"
+        },
+        {
+          "@id": "estleg:EU_32007L0047"
+        },
+        {
+          "@id": "estleg:EU_32008L0015"
+        },
+        {
+          "@id": "estleg:EU_32007L0070"
+        },
+        {
+          "@id": "estleg:EU_32009L0087"
+        },
+        {
+          "@id": "estleg:EU_32009L0089"
+        },
+        {
+          "@id": "estleg:EU_32009L0085"
+        },
+        {
+          "@id": "estleg:EU_32008L0080"
+        },
+        {
+          "@id": "estleg:EU_32008L0079"
+        },
+        {
+          "@id": "estleg:EU_32008L0078"
+        },
+        {
+          "@id": "estleg:EU_32009L0086"
+        },
+        {
+          "@id": "estleg:EU_32006L0140"
+        },
+        {
+          "@id": "estleg:EU_32009L0088"
+        },
+        {
+          "@id": "estleg:EU_32008L0077"
+        },
+        {
+          "@id": "estleg:EU_32008L0016"
+        },
+        {
+          "@id": "estleg:EU_32008L0081"
+        },
+        {
+          "@id": "estleg:EU_32009L0092"
+        },
+        {
+          "@id": "estleg:EU_32007L0020"
+        },
+        {
+          "@id": "estleg:EU_32008L0075"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_BIOTSI",

--- a/krr_outputs/controlled_vocabulary.jsonld
+++ b/krr_outputs/controlled_vocabulary.jsonld
@@ -1932,6 +1932,17 @@
       "rdfs:comment": "Reusable property observed in generated corpus and materialized for vocabulary coverage validation."
     },
     {
+      "@id": "estleg:transpositionDeadline",
+      "@type": [
+        "owl:DatatypeProperty"
+      ],
+      "rdfs:label": "Transposition Deadline",
+      "rdfs:comment": "Deadline by which EU member states must transpose an EU directive into national law (from cdm:directive_date_transposition). Present only on directive nodes that declare one.",
+      "rdfs:range": {
+        "@id": "xsd:date"
+      }
+    },
+    {
       "@id": "estleg:referenceStatus",
       "@type": [
         "owl:DatatypeProperty"

--- a/krr_outputs/eesti_territooriumi_haldusjaotuse_seadus_peep.json
+++ b/krr_outputs/eesti_territooriumi_haldusjaotuse_seadus_peep.json
@@ -76,7 +76,13 @@
         {
           "@id": "http://eurovoc.europa.eu/6411"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32007L0002"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_ETH",

--- a/krr_outputs/eesti_vaartpaberite_keskregistri_seadus_peep.json
+++ b/krr_outputs/eesti_vaartpaberite_keskregistri_seadus_peep.json
@@ -52,7 +52,13 @@
         {
           "@id": "http://eurovoc.europa.eu/3611"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32007L0036"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_EVKS",

--- a/krr_outputs/eesti_vabariigi_haridusseadus_peep.json
+++ b/krr_outputs/eesti_vabariigi_haridusseadus_peep.json
@@ -55,7 +55,13 @@
         {
           "@id": "http://eurovoc.europa.eu/5231"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32005L0036"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_EVH",

--- a/krr_outputs/eestisse_lahetatud_tootajate_tootingimuste_seadus_peep.json
+++ b/krr_outputs/eestisse_lahetatud_tootajate_tootingimuste_seadus_peep.json
@@ -58,7 +58,13 @@
         {
           "@id": "http://eurovoc.europa.eu/2446"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_31996L0071"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_ELTTS",

--- a/krr_outputs/elektrituruseadus_peep.json
+++ b/krr_outputs/elektrituruseadus_peep.json
@@ -81,7 +81,16 @@
         {
           "@id": "http://eurovoc.europa.eu/2841"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32009L0028"
+        },
+        {
+          "@id": "estleg:EU_32009L0072"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_ELTS",

--- a/krr_outputs/elektroonilise_side_seadus_peep.json
+++ b/krr_outputs/elektroonilise_side_seadus_peep.json
@@ -139,7 +139,16 @@
         {
           "@id": "http://eurovoc.europa.eu/0411"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32009L0136"
+        },
+        {
+          "@id": "estleg:EU_32009L0140"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_ESS",

--- a/krr_outputs/eurlex/eurlex_directives_peep.json
+++ b/krr_outputs/eurlex/eurlex_directives_peep.json
@@ -48,6 +48,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1981-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -79,6 +83,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2000-05-13",
+        "@type": "xsd:date"
       }
     },
     {
@@ -291,7 +299,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2011-06-30",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31989L0014",
@@ -322,6 +334,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1990-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -353,6 +369,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1997-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -384,6 +404,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2009-09-06",
+        "@type": "xsd:date"
       }
     },
     {
@@ -415,6 +439,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -446,6 +474,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1979-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -477,6 +509,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1984-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -508,6 +544,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2015-06-11",
+        "@type": "xsd:date"
       }
     },
     {
@@ -539,6 +579,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1997-04-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -570,6 +614,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1997-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -642,7 +690,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2013-10-31",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32000L0004",
@@ -678,7 +730,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2001-04-07",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32014L0098",
@@ -709,6 +765,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2016-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -745,7 +805,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2001-05-03",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31997L0045",
@@ -776,6 +840,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1998-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -807,6 +875,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-03-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -838,6 +910,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1995-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -869,6 +945,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2010-08-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -900,6 +985,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1977-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -967,6 +1056,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1981-12-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -998,6 +1091,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1978-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -1060,6 +1157,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -1191,7 +1292,34 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:PLANEE_2_Map_2026"
+        },
+        {
+          "@id": "estleg:VetKS_Map_2026"
+        },
+        {
+          "@id": "estleg:EVH_Map_2026"
+        },
+        {
+          "@id": "estleg:RakKKS_Map_2026"
+        },
+        {
+          "@id": "estleg:RavS_Map_2026"
+        },
+        {
+          "@id": "estleg:TTKS_Map_2026"
+        },
+        {
+          "@id": "estleg:ÜKS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2007-10-20",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31992L0083",
@@ -1222,6 +1350,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -1253,6 +1385,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2001-02-28",
+        "@type": "xsd:date"
       }
     },
     {
@@ -1284,6 +1420,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1996-06-22",
+        "@type": "xsd:date"
       }
     },
     {
@@ -1320,7 +1460,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2007-01-20",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31999L0070",
@@ -1351,6 +1495,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2001-07-10",
+        "@type": "xsd:date"
       }
     },
     {
@@ -1382,6 +1530,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -1418,7 +1570,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2006-05-20",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32014L0031",
@@ -1454,7 +1610,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2016-04-19",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32002L0098",
@@ -1490,7 +1650,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2005-02-08",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32005L0015",
@@ -1521,6 +1685,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2005-02-28",
+        "@type": "xsd:date"
       }
     },
     {
@@ -1583,6 +1751,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2014-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -1614,6 +1786,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2003-04-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -1645,6 +1821,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1971-07-27",
+        "@type": "xsd:date"
       }
     },
     {
@@ -1712,6 +1892,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-05-19",
+        "@type": "xsd:date"
       }
     },
     {
@@ -1774,6 +1958,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2009-02-14",
+        "@type": "xsd:date"
       }
     },
     {
@@ -1805,6 +1993,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -1836,6 +2028,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1973-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -1872,7 +2068,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2004-07-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32001L0083",
@@ -1944,7 +2144,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2006-08-11",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32015L0559",
@@ -1975,6 +2179,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2016-04-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -2011,7 +2219,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1998-10-24",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31990L0167",
@@ -2042,6 +2254,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1991-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -2073,6 +2289,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-02-18",
+        "@type": "xsd:date"
       }
     },
     {
@@ -2104,6 +2324,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1978-12-17",
+        "@type": "xsd:date"
       }
     },
     {
@@ -2140,7 +2364,16 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:TarbKS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2007-06-12",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31981L0464",
@@ -2171,6 +2404,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1981-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -2202,6 +2439,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-10-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -2233,6 +2474,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1972-02-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -2264,6 +2509,27 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "https://data.riik.ee/ontology/estleg#"
+        },
+        {
+          "@id": "estleg:VOS_Osa1_1_207"
+        },
+        {
+          "@id": "estleg:VOS_Osa3_Contract_Obligations_Liability"
+        },
+        {
+          "@id": "estleg:VOS_Osa4_Taitmine_Tasaarvestus_Vabastamine"
+        },
+        {
+          "@id": "estleg:VOS_Osa7_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1994-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -2300,7 +2566,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1995-12-31",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31989L0108",
@@ -2331,6 +2601,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1990-07-10",
+        "@type": "xsd:date"
       }
     },
     {
@@ -2362,6 +2636,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1982-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -2393,6 +2671,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1988-07-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -2424,6 +2706,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1965-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -2460,7 +2746,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1997-05-20",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32009L0096",
@@ -2491,6 +2781,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2011-09-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -2522,6 +2821,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1981-08-02",
+        "@type": "xsd:date"
       }
     },
     {
@@ -2584,6 +2887,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-10-10",
+        "@type": "xsd:date"
       }
     },
     {
@@ -2615,6 +2922,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -2646,6 +2957,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2003-10-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -2677,6 +2992,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1995-03-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -2708,6 +3027,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1988-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -2739,6 +3062,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1978-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -2770,6 +3097,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1979-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -2801,6 +3132,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2005-11-19",
+        "@type": "xsd:date"
       }
     },
     {
@@ -2837,7 +3172,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2017-06-26",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32009L0092",
@@ -2868,6 +3207,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2010-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -2899,6 +3247,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1976-10-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -2930,6 +3282,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2001-06-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -2961,6 +3317,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2001-05-05",
+        "@type": "xsd:date"
       }
     },
     {
@@ -2992,6 +3352,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1991-06-07",
+        "@type": "xsd:date"
       }
     },
     {
@@ -3023,6 +3387,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2003-12-02",
+        "@type": "xsd:date"
       }
     },
     {
@@ -3059,7 +3427,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2008-09-28",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32014L0091",
@@ -3095,7 +3467,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2016-03-18",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32003L0098",
@@ -3131,7 +3507,28 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:HKTS_Map_2026"
+        },
+        {
+          "@id": "estleg:HMS_Map_2026"
+        },
+        {
+          "@id": "estleg:ISIKUA_Map_2026"
+        },
+        {
+          "@id": "estleg:RIIGIL_2_Map_2026"
+        },
+        {
+          "@id": "estleg:AVTS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2005-07-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32006L0103",
@@ -3162,6 +3559,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -3193,6 +3594,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -3224,6 +3629,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2010-10-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -3255,6 +3664,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-10-12",
+        "@type": "xsd:date"
       }
     },
     {
@@ -3286,6 +3699,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -3322,7 +3739,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2002-07-30",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32009L0084",
@@ -3353,6 +3774,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2010-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -3384,6 +3814,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1975-04-18",
+        "@type": "xsd:date"
       }
     },
     {
@@ -3415,6 +3849,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1982-04-22",
+        "@type": "xsd:date"
       }
     },
     {
@@ -3487,7 +3925,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2006-12-30",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32003L0096",
@@ -3518,6 +3960,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2003-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -3554,7 +4000,19 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:VEE_Map_2026"
+        },
+        {
+          "@id": "estleg:KeVS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2003-12-22",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31991L0155",
@@ -3585,6 +4043,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1991-05-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -3616,6 +4078,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-11-24",
+        "@type": "xsd:date"
       }
     },
     {
@@ -3647,6 +4113,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-10-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -3678,6 +4148,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -3709,6 +4183,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1978-02-03",
+        "@type": "xsd:date"
       }
     },
     {
@@ -3740,6 +4218,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1970-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -3771,6 +4253,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1977-07-17",
+        "@type": "xsd:date"
       }
     },
     {
@@ -3807,7 +4293,16 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:INVEST_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2011-12-31",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31978L0660",
@@ -3838,6 +4333,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1980-07-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -3869,6 +4368,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1980-01-28",
+        "@type": "xsd:date"
       }
     },
     {
@@ -3905,7 +4408,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2007-12-15",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31968L0151",
@@ -3936,6 +4443,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1969-09-11",
+        "@type": "xsd:date"
       }
     },
     {
@@ -3967,6 +4478,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2002-04-09",
+        "@type": "xsd:date"
       }
     },
     {
@@ -4003,7 +4518,16 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:VÕKS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2012-12-31",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32000L0027",
@@ -4034,6 +4558,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2000-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -4065,6 +4593,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1973-11-22",
+        "@type": "xsd:date"
       }
     },
     {
@@ -4127,6 +4659,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -4163,7 +4699,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2006-01-04",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31992L0118",
@@ -4194,6 +4734,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -4230,7 +4774,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1997-12-31",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32000L0043",
@@ -4261,6 +4809,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2003-07-19",
+        "@type": "xsd:date"
       }
     },
     {
@@ -4292,6 +4844,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-07-26",
+        "@type": "xsd:date"
       }
     },
     {
@@ -4323,6 +4879,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1987-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -4354,6 +4914,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-11-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -4390,7 +4954,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2006-02-14",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32011L0061",
@@ -4426,7 +4994,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2013-07-22",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32003L0008",
@@ -4457,6 +5029,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-11-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -4519,6 +5095,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -4550,6 +5130,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -4581,6 +5165,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-10-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -4617,7 +5205,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2005-10-30",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32009L0061",
@@ -4653,7 +5245,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1980-04-25",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31999L0035",
@@ -4684,6 +5280,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2000-12-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -4715,6 +5315,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1972-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -4746,6 +5350,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1979-12-17",
+        "@type": "xsd:date"
       }
     },
     {
@@ -4782,7 +5390,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2006-12-29",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31978L0932",
@@ -4813,6 +5425,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1980-04-19",
+        "@type": "xsd:date"
       }
     },
     {
@@ -4844,6 +5460,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1989-10-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -4875,6 +5495,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1977-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -4911,7 +5535,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1998-12-03",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31994L0031",
@@ -4973,6 +5601,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1981-09-18",
+        "@type": "xsd:date"
       }
     },
     {
@@ -5004,6 +5636,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-12-19",
+        "@type": "xsd:date"
       }
     },
     {
@@ -5035,6 +5671,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2012-10-05",
+        "@type": "xsd:date"
       }
     },
     {
@@ -5066,6 +5706,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2012-06-10",
+        "@type": "xsd:date"
       }
     },
     {
@@ -5097,6 +5741,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2016-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -5133,7 +5781,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2015-02-28",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32008L0004",
@@ -5164,6 +5816,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2008-07-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -5200,7 +5856,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2008-12-30",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31974L0290",
@@ -5231,6 +5891,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1974-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -5262,6 +5926,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -5293,6 +5961,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:LKS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1994-06-10",
+        "@type": "xsd:date"
       }
     },
     {
@@ -5324,6 +6001,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -5360,7 +6041,34 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:Maapueseadus_Map_2026"
+        },
+        {
+          "@id": "estleg:KeVS_Map_2026"
+        },
+        {
+          "@id": "estleg:KeHJS_Map_2026"
+        },
+        {
+          "@id": "estleg:VÕKS_Map_2026"
+        },
+        {
+          "@id": "estleg:VEE_Map_2026"
+        },
+        {
+          "@id": "estleg:SVKS_Map_2026"
+        },
+        {
+          "@id": "estleg:JäätS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2011-06-25",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31987L0354",
@@ -5391,6 +6099,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1987-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -5427,7 +6139,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2013-12-31",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32011L0002",
@@ -5458,6 +6174,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-11-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -5489,6 +6209,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1971-08-10",
+        "@type": "xsd:date"
       }
     },
     {
@@ -5520,6 +6244,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1995-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -5551,6 +6279,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-12-11",
+        "@type": "xsd:date"
       }
     },
     {
@@ -5587,7 +6319,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1998-10-13",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31989L0517",
@@ -5618,6 +6354,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1989-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -5649,6 +6389,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1979-03-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -5685,7 +6429,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2002-11-17",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32004L0093",
@@ -5716,6 +6464,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -5747,6 +6499,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1995-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -5778,6 +6534,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2003-07-24",
+        "@type": "xsd:date"
       }
     },
     {
@@ -5809,6 +6569,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1997-12-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -5840,6 +6604,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-12-07",
+        "@type": "xsd:date"
       }
     },
     {
@@ -5871,6 +6639,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1981-04-07",
+        "@type": "xsd:date"
       }
     },
     {
@@ -5938,6 +6710,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1997-10-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -5969,6 +6745,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2013-08-23",
+        "@type": "xsd:date"
       }
     },
     {
@@ -6000,6 +6780,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1991-11-27",
+        "@type": "xsd:date"
       }
     },
     {
@@ -6036,7 +6820,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2004-11-16",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31964L0433",
@@ -6067,6 +6855,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1965-06-29",
+        "@type": "xsd:date"
       }
     },
     {
@@ -6098,6 +6890,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2003-08-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -6129,6 +6925,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-06-18",
+        "@type": "xsd:date"
       }
     },
     {
@@ -6160,6 +6960,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -6191,6 +6995,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -6222,6 +7030,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1968-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -6253,6 +7065,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1986-10-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -6284,6 +7100,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1995-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -6315,6 +7135,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1995-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -6346,6 +7170,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2016-05-20",
+        "@type": "xsd:date"
       }
     },
     {
@@ -6377,6 +7205,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2014-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -6408,6 +7240,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1979-03-25",
+        "@type": "xsd:date"
       }
     },
     {
@@ -6475,6 +7311,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -6542,6 +7382,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1989-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -6573,6 +7417,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-10-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -6604,6 +7452,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1991-04-04",
+        "@type": "xsd:date"
       }
     },
     {
@@ -6635,6 +7487,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1991-01-04",
+        "@type": "xsd:date"
       }
     },
     {
@@ -6671,7 +7527,16 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:JäätS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2010-12-12",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32002L0030",
@@ -6743,7 +7608,16 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:ESS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2011-05-25",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32002L0021",
@@ -6810,6 +7684,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-10-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -6872,6 +7750,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2010-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -6903,6 +7785,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -6934,6 +7820,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -6965,6 +7855,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -6996,6 +7890,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1998-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -7027,6 +7925,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2000-01-20",
+        "@type": "xsd:date"
       }
     },
     {
@@ -7058,6 +7960,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-02-15",
+        "@type": "xsd:date"
       }
     },
     {
@@ -7125,6 +8031,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2009-01-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -7156,6 +8071,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1977-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -7187,6 +8106,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -7218,6 +8141,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1996-11-21",
+        "@type": "xsd:date"
       }
     },
     {
@@ -7254,7 +8181,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2005-12-31",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31976L0761",
@@ -7285,6 +8216,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1977-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -7357,7 +8292,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2014-07-04",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31999L0031",
@@ -7388,6 +8327,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:JäätS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2001-07-16",
+        "@type": "xsd:date"
       }
     },
     {
@@ -7419,6 +8367,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1973-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -7450,6 +8402,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2013-10-25",
+        "@type": "xsd:date"
       }
     },
     {
@@ -7486,7 +8442,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2002-12-28",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31984L0539",
@@ -7517,6 +8477,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1986-09-26",
+        "@type": "xsd:date"
       }
     },
     {
@@ -7548,6 +8512,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -7579,6 +8547,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2002-01-25",
+        "@type": "xsd:date"
       }
     },
     {
@@ -7610,6 +8582,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2010-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -7641,6 +8617,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -7703,6 +8683,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-02-03",
+        "@type": "xsd:date"
       }
     },
     {
@@ -7734,6 +8718,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-04-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -7765,6 +8753,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-01-23",
+        "@type": "xsd:date"
       }
     },
     {
@@ -7796,6 +8788,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -7827,6 +8823,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -7858,6 +8858,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -7889,6 +8893,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -7920,6 +8928,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-12-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -7951,6 +8963,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -7987,7 +9003,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2016-01-18",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32008L0056",
@@ -8023,7 +9043,16 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:VEE_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2010-07-15",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31999L0057",
@@ -8054,6 +9083,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2000-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -8085,6 +9118,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -8121,7 +9158,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2011-05-20",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31986L0280",
@@ -8152,6 +9193,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1988-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -8183,6 +9228,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2015-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -8214,6 +9263,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2009-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -8245,6 +9303,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1989-07-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -8276,6 +9338,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2000-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -8312,7 +9378,19 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:KARIST_2_Osa1_1_87"
+        },
+        {
+          "@id": "estleg:KARIST_2_Osa2_88_451"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2010-12-26",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32013L0040",
@@ -8348,7 +9426,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2015-09-04",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31985L0503",
@@ -8379,6 +9461,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1987-05-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -8410,6 +9496,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1995-11-23",
+        "@type": "xsd:date"
       }
     },
     {
@@ -8446,7 +9536,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2006-04-30",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32006L0080",
@@ -8477,6 +9571,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -8544,7 +9642,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2001-12-13",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31992L0058",
@@ -8575,6 +9677,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-06-24",
+        "@type": "xsd:date"
       }
     },
     {
@@ -8606,6 +9712,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2008-03-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -8642,6 +9752,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:RAUDTEE_Map_2026"
+        }
       ]
     },
     {
@@ -8673,6 +9788,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2013-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -8709,7 +9828,40 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:REÕS_Map_2026"
+        },
+        {
+          "@id": "estleg:TarbKS_Map_2026"
+        },
+        {
+          "@id": "https://data.riik.ee/ontology/estleg#"
+        },
+        {
+          "@id": "estleg:VOS_Osa1_1_207"
+        },
+        {
+          "@id": "estleg:VOS_Osa3_Contract_Obligations_Liability"
+        },
+        {
+          "@id": "estleg:VOS_Osa4_Taitmine_Tasaarvestus_Vabastamine"
+        },
+        {
+          "@id": "estleg:VOS_Osa7_Map_2026"
+        },
+        {
+          "@id": "estleg:ISIKUA_Map_2026"
+        },
+        {
+          "@id": "estleg:REKLAA_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2010-06-11",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31998L0079",
@@ -8745,7 +9897,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1999-12-07",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32007L0058",
@@ -8781,7 +9937,16 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:RAUDTEE_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2009-06-03",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31987L0120",
@@ -8812,6 +9977,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1988-06-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -8848,7 +10017,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1997-09-03",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31989L0107",
@@ -8879,6 +10052,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1990-06-27",
+        "@type": "xsd:date"
       }
     },
     {
@@ -8915,7 +10092,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2016-07-03",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32008L0062",
@@ -8946,6 +10127,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:TPSKS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2009-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -8977,6 +10167,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2008-10-04",
+        "@type": "xsd:date"
       }
     },
     {
@@ -9008,7 +10202,12 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
-      }
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:KMS_Map_2026"
+        }
+      ]
     },
     {
       "@id": "estleg:EU_32012L0022",
@@ -9039,6 +10238,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2013-01-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -9075,7 +10283,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2007-04-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32001L0088",
@@ -9137,6 +10349,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -9168,6 +10384,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1989-12-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -9199,6 +10419,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1988-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -9230,6 +10454,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -9261,6 +10489,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1991-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -9328,7 +10560,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1998-12-30",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31985L0010",
@@ -9359,6 +10595,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1985-12-20",
+        "@type": "xsd:date"
       }
     },
     {
@@ -9390,6 +10630,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1990-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -9457,7 +10701,19 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:RAUDTEE_Map_2026"
+        },
+        {
+          "@id": "estleg:TLS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2009-12-03",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31993L0050",
@@ -9488,6 +10744,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-06-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -9550,6 +10810,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1996-11-23",
+        "@type": "xsd:date"
       }
     },
     {
@@ -9586,7 +10850,16 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:LIIKLU_2_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2011-01-19",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32003L0087",
@@ -9622,7 +10895,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2003-12-31",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32001L0019",
@@ -9689,6 +10966,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-10-05",
+        "@type": "xsd:date"
       }
     },
     {
@@ -9725,7 +11006,19 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:RAUDTEE_Map_2026"
+        },
+        {
+          "@id": "estleg:TNV_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2010-07-19",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32009L0044",
@@ -9761,7 +11054,76 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:AOS_Osa10_YhineOmandJaKaasomand"
+        },
+        {
+          "@id": "estleg:AOS_Osa11_UhisomandAbieluvara"
+        },
+        {
+          "@id": "estleg:AOS_Osa1_Uldosa"
+        },
+        {
+          "@id": "estleg:AOS_Osa2_Omand"
+        },
+        {
+          "@id": "estleg:AOS_Osa3_Hoonestusoigus"
+        },
+        {
+          "@id": "estleg:AOS_Osa4_Uhisomand"
+        },
+        {
+          "@id": "estleg:AOS_Osa5_AsjaoigusteKaitse_Voorandamine"
+        },
+        {
+          "@id": "estleg:AOS_Osa6_13_Jatku"
+        },
+        {
+          "@id": "estleg:AOS_Osa7_Servituudid"
+        },
+        {
+          "@id": "estleg:AOS_Osa8_AsjaoigusteKaitse_Map_2026"
+        },
+        {
+          "@id": "estleg:AOS_Osa9_OmandiOmandamine"
+        },
+        {
+          "@id": "estleg:VPTS_Map_2026"
+        },
+        {
+          "@id": "estleg:AÕSRS_Map_2026"
+        },
+        {
+          "@id": "estleg:PANKR_Map_2026"
+        },
+        {
+          "@id": "estleg:KREDII_2_Map_2026"
+        },
+        {
+          "@id": "estleg:KINDLU_Map_2026"
+        },
+        {
+          "@id": "https://data.riik.ee/ontology/estleg#"
+        },
+        {
+          "@id": "estleg:VOS_Osa1_1_207"
+        },
+        {
+          "@id": "estleg:VOS_Osa3_Contract_Obligations_Liability"
+        },
+        {
+          "@id": "estleg:VOS_Osa4_Taitmine_Tasaarvestus_Vabastamine"
+        },
+        {
+          "@id": "estleg:VOS_Osa7_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2010-12-30",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31990L0612",
@@ -9792,6 +11154,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1991-11-12",
+        "@type": "xsd:date"
       }
     },
     {
@@ -9828,7 +11194,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2005-05-11",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32002L0084",
@@ -9864,7 +11234,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2003-11-23",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32003L0103",
@@ -9900,7 +11274,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2005-05-14",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32004L0027",
@@ -9936,7 +11314,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2005-10-30",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31986L0096",
@@ -9967,6 +11349,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1987-09-18",
+        "@type": "xsd:date"
       }
     },
     {
@@ -9998,6 +11384,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1991-10-03",
+        "@type": "xsd:date"
       }
     },
     {
@@ -10029,6 +11419,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1983-10-14",
+        "@type": "xsd:date"
       }
     },
     {
@@ -10065,7 +11459,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2004-08-13",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31976L0207",
@@ -10096,6 +11494,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1978-08-12",
+        "@type": "xsd:date"
       }
     },
     {
@@ -10132,7 +11534,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2000-07-30",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31988L0599",
@@ -10163,6 +11569,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1989-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -10194,6 +11604,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1987-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -10225,6 +11639,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2008-10-19",
+        "@type": "xsd:date"
       }
     },
     {
@@ -10256,6 +11674,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -10323,6 +11745,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2002-01-20",
+        "@type": "xsd:date"
       }
     },
     {
@@ -10359,7 +11785,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2007-10-20",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31982L0475",
@@ -10390,6 +11820,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1985-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -10457,6 +11891,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1982-01-17",
+        "@type": "xsd:date"
       }
     },
     {
@@ -10488,6 +11926,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1990-09-26",
+        "@type": "xsd:date"
       }
     },
     {
@@ -10524,7 +11966,16 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:JäätS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2004-08-12",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31996L0055",
@@ -10555,6 +12006,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1997-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -10586,6 +12041,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1980-12-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -10617,6 +12076,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1990-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -10648,6 +12111,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1976-06-19",
+        "@type": "xsd:date"
       }
     },
     {
@@ -10684,7 +12151,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2005-01-14",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31993L0041",
@@ -10715,6 +12186,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1995-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -10746,6 +12221,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1988-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -10777,6 +12256,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2005-09-29",
+        "@type": "xsd:date"
       }
     },
     {
@@ -10844,7 +12327,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2016-04-19",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31989L0105",
@@ -10875,6 +12362,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1989-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -10911,7 +12402,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2000-05-13",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32007L0060",
@@ -10947,7 +12442,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2009-11-25",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31992L0109",
@@ -10978,6 +12477,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -11009,6 +12512,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1978-08-02",
+        "@type": "xsd:date"
       }
     },
     {
@@ -11040,6 +12547,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-11-15",
+        "@type": "xsd:date"
       }
     },
     {
@@ -11102,6 +12613,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1978-12-29",
+        "@type": "xsd:date"
       }
     },
     {
@@ -11133,6 +12648,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1970-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -11164,6 +12683,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1975-12-18",
+        "@type": "xsd:date"
       }
     },
     {
@@ -11195,6 +12718,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2001-03-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -11262,7 +12789,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2016-09-30",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32011L0007",
@@ -11298,7 +12829,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2013-03-16",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32004L0002",
@@ -11329,6 +12864,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-07-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -11360,6 +12899,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1978-11-26",
+        "@type": "xsd:date"
       }
     },
     {
@@ -11427,7 +12970,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2008-05-17",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31996L0067",
@@ -11458,6 +13005,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1997-10-25",
+        "@type": "xsd:date"
       }
     },
     {
@@ -11525,7 +13076,16 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:VÕKS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2010-02-02",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31995L0061",
@@ -11556,6 +13116,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1996-10-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -11587,6 +13151,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1973-02-18",
+        "@type": "xsd:date"
       }
     },
     {
@@ -11623,7 +13191,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2000-03-14",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32014L0084",
@@ -11654,6 +13226,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2015-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -11685,6 +13261,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -11716,6 +13296,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2015-12-21",
+        "@type": "xsd:date"
       }
     },
     {
@@ -11747,6 +13331,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2003-07-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -11778,6 +13366,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-05-09",
+        "@type": "xsd:date"
       }
     },
     {
@@ -11809,6 +13401,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-06-11",
+        "@type": "xsd:date"
       }
     },
     {
@@ -11845,7 +13441,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2006-04-30",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32004L0059",
@@ -11876,6 +13476,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-10-24",
+        "@type": "xsd:date"
       }
     },
     {
@@ -11907,6 +13511,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1988-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -11969,6 +13577,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-03-06",
+        "@type": "xsd:date"
       }
     },
     {
@@ -12000,6 +13612,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2003-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -12036,7 +13652,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1998-12-17",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32005L0007",
@@ -12067,6 +13687,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-02-18",
+        "@type": "xsd:date"
       }
     },
     {
@@ -12098,6 +13722,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -12129,6 +13757,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -12160,6 +13792,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1986-03-12",
+        "@type": "xsd:date"
       }
     },
     {
@@ -12191,6 +13827,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2000-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -12222,6 +13862,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1978-01-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -12258,7 +13902,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2016-09-18",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32014L0081",
@@ -12289,6 +13937,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2015-12-21",
+        "@type": "xsd:date"
       }
     },
     {
@@ -12320,6 +13972,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1986-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -12351,6 +14007,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-03-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -12382,6 +14042,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2000-01-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -12413,6 +14077,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1997-04-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -12444,6 +14112,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1996-08-22",
+        "@type": "xsd:date"
       }
     },
     {
@@ -12475,6 +14147,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1984-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -12506,6 +14182,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1981-03-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -12537,6 +14217,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1988-07-03",
+        "@type": "xsd:date"
       }
     },
     {
@@ -12599,6 +14283,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-06-14",
+        "@type": "xsd:date"
       }
     },
     {
@@ -12635,7 +14323,16 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:VRKS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2015-07-20",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32013L0054",
@@ -12671,7 +14368,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2015-03-31",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31994L0029",
@@ -12702,6 +14403,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1995-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -12733,6 +14438,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1996-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -12764,6 +14473,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1997-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -12857,6 +14570,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2003-05-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -12919,6 +14636,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -12950,6 +14671,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2001-03-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -12981,6 +14706,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1982-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -13012,6 +14741,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1998-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -13043,6 +14776,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1988-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -13074,6 +14811,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1989-08-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -13105,6 +14846,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1997-04-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -13136,6 +14881,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-04-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -13203,7 +14952,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2000-04-07",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31992L0050",
@@ -13234,6 +14987,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -13265,6 +15022,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1984-12-23",
+        "@type": "xsd:date"
       }
     },
     {
@@ -13332,6 +15093,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1974-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -13363,6 +15128,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2001-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -13394,6 +15163,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2016-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -13425,6 +15198,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2001-03-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -13456,6 +15233,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2014-08-20",
+        "@type": "xsd:date"
       }
     },
     {
@@ -13487,6 +15268,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1973-10-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -13518,6 +15303,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1981-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -13554,7 +15343,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2002-08-07",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31980L0233",
@@ -13585,6 +15378,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1980-04-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -13616,6 +15413,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2003-07-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -13647,6 +15448,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -13683,7 +15488,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2007-01-31",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32013L0032",
@@ -13719,7 +15528,16 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:VRKS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2015-07-20",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31999L0046",
@@ -13750,6 +15568,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -13822,7 +15644,28 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:TsÜS_Osa2_7_47"
+        },
+        {
+          "@id": "estleg:TsÜS_Osa4_67_131"
+        },
+        {
+          "@id": "estleg:TsÜS_Osa7_138_169"
+        },
+        {
+          "@id": "estleg:riseadustik1_Map_2026"
+        },
+        {
+          "@id": "estleg:EVKS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2009-08-03",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32007L0013",
@@ -13853,6 +15696,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2008-03-10",
+        "@type": "xsd:date"
       }
     },
     {
@@ -13915,6 +15762,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1982-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -13946,6 +15797,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-01-11",
+        "@type": "xsd:date"
       }
     },
     {
@@ -13977,6 +15832,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1976-02-12",
+        "@type": "xsd:date"
       }
     },
     {
@@ -14008,6 +15867,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-11-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -14044,7 +15907,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2005-02-14",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32013L0055",
@@ -14080,7 +15947,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2016-01-18",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31978L1026",
@@ -14111,6 +15982,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1980-12-22",
+        "@type": "xsd:date"
       }
     },
     {
@@ -14142,6 +16017,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2001-04-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -14173,6 +16052,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1973-01-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -14204,6 +16087,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-01-20",
+        "@type": "xsd:date"
       }
     },
     {
@@ -14235,6 +16122,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1984-12-10",
+        "@type": "xsd:date"
       }
     },
     {
@@ -14302,6 +16193,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -14333,6 +16228,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1984-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -14364,6 +16263,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1979-02-21",
+        "@type": "xsd:date"
       }
     },
     {
@@ -14395,6 +16298,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -14426,6 +16333,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1977-04-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -14462,7 +16373,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2006-04-14",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31986L0609",
@@ -14493,6 +16408,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1989-11-24",
+        "@type": "xsd:date"
       }
     },
     {
@@ -14560,6 +16479,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -14591,6 +16514,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-06-15",
+        "@type": "xsd:date"
       }
     },
     {
@@ -14663,7 +16590,31 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:RAUDTEE_Map_2026"
+        },
+        {
+          "@id": "estleg:HMS_Map_2026"
+        },
+        {
+          "@id": "estleg:RIIGIL_2_Map_2026"
+        },
+        {
+          "@id": "estleg:MSOS_Map_2026"
+        },
+        {
+          "@id": "estleg:HALDUS_Map_2026"
+        },
+        {
+          "@id": "estleg:VABARI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2006-04-30",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32008L0109",
@@ -14694,6 +16645,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2008-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -14725,6 +16680,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1979-06-15",
+        "@type": "xsd:date"
       }
     },
     {
@@ -14797,7 +16756,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2016-01-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31992L0070",
@@ -14859,6 +16822,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -14890,6 +16857,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-08-05",
+        "@type": "xsd:date"
       }
     },
     {
@@ -14921,6 +16892,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1988-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -14952,6 +16927,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1977-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -14988,7 +16967,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1996-06-29",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32005L0054",
@@ -15019,6 +17002,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-08-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -15050,6 +17037,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1995-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -15086,7 +17077,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2002-10-17",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32006L0104",
@@ -15117,6 +17112,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -15148,6 +17147,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1982-10-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -15179,6 +17182,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-05-05",
+        "@type": "xsd:date"
       }
     },
     {
@@ -15210,6 +17217,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -15241,6 +17252,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -15277,7 +17292,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2004-11-25",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32008L0073",
@@ -15308,6 +17327,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:LTTS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2010-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -15339,6 +17367,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1972-11-23",
+        "@type": "xsd:date"
       }
     },
     {
@@ -15375,7 +17407,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2001-07-18",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31992L0079",
@@ -15406,6 +17442,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -15437,6 +17477,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1989-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -15468,6 +17512,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1978-12-29",
+        "@type": "xsd:date"
       }
     },
     {
@@ -15499,6 +17547,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2014-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -15530,6 +17582,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-11-03",
+        "@type": "xsd:date"
       }
     },
     {
@@ -15592,6 +17648,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -15623,6 +17683,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1995-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -15654,6 +17718,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2008-12-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -15685,6 +17753,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2001-03-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -15721,7 +17793,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2015-11-16",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32001L0077",
@@ -15788,6 +17864,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1991-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -15819,6 +17899,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2001-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -15850,6 +17934,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -15881,6 +17969,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1974-08-21",
+        "@type": "xsd:date"
       }
     },
     {
@@ -15917,7 +18009,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2004-07-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31989L0361",
@@ -15948,6 +18044,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1991-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -16010,6 +18110,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1991-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -16077,6 +18181,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-10-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -16113,7 +18221,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2005-08-18",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31989L0384",
@@ -16144,6 +18256,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1990-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -16175,6 +18291,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1977-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -16211,7 +18331,22 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:KINDLU_Map_2026"
+        },
+        {
+          "@id": "estleg:VPTS_Map_2026"
+        },
+        {
+          "@id": "estleg:INVEST_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2009-03-20",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31985L0327",
@@ -16242,6 +18377,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1986-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -16278,7 +18417,34 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:TeeS_Map_2026"
+        },
+        {
+          "@id": "estleg:NS_Map_2026"
+        },
+        {
+          "@id": "estleg:MaaKatS_Map_2026"
+        },
+        {
+          "@id": "estleg:KeRS_Map_2026"
+        },
+        {
+          "@id": "estleg:RAS_Map_2026"
+        },
+        {
+          "@id": "estleg:AVTS_Map_2026"
+        },
+        {
+          "@id": "estleg:ETH_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2009-05-14",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31984L0641",
@@ -16309,6 +18475,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1987-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -16340,6 +18510,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2010-04-05",
+        "@type": "xsd:date"
       }
     },
     {
@@ -16371,6 +18545,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:VEE_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2011-08-21",
+        "@type": "xsd:date"
       }
     },
     {
@@ -16402,6 +18585,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1987-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -16438,7 +18625,16 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:JäätS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2005-06-25",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32013L0035",
@@ -16474,7 +18670,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2016-07-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32009L0028",
@@ -16510,7 +18710,40 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:RIIGIH_Map_2026"
+        },
+        {
+          "@id": "estleg:ATKE_Map_2026"
+        },
+        {
+          "@id": "estleg:Kutseseadus_Map_2026"
+        },
+        {
+          "@id": "estleg:PLANEE_2_Map_2026"
+        },
+        {
+          "@id": "estleg:VABARI_Map_2026"
+        },
+        {
+          "@id": "estleg:ELTS_Map_2026"
+        },
+        {
+          "@id": "estleg:KAUGKU_Map_2026"
+        },
+        {
+          "@id": "estleg:RIIGIL_2_Map_2026"
+        },
+        {
+          "@id": "estleg:TarbKS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2010-12-05",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31977L0799",
@@ -16541,6 +18774,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1979-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -16572,6 +18809,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2009-03-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -16603,6 +18844,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2003-12-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -16639,7 +18884,19 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:HALDUS_Map_2026"
+        },
+        {
+          "@id": "estleg:SVKS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1999-10-30",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32014L0040",
@@ -16675,7 +18932,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2016-05-20",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31990L0618",
@@ -16706,6 +18967,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-05-20",
+        "@type": "xsd:date"
       }
     },
     {
@@ -16737,6 +19002,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -16826,6 +19095,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1998-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -16857,6 +19130,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-10-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -16888,6 +19165,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2012-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -16924,7 +19210,22 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:KARIST_2_Osa1_1_87"
+        },
+        {
+          "@id": "estleg:KARIST_2_Osa2_88_451"
+        },
+        {
+          "@id": "estleg:STRATE_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2011-06-30",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31991L0493",
@@ -16955,6 +19256,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -17022,7 +19327,16 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:LENN_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2011-03-15",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31985L0572",
@@ -17089,7 +19403,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1994-06-30",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32009L0003",
@@ -17125,7 +19443,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2009-12-31",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32000L0069",
@@ -17161,7 +19483,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2002-12-13",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32007L0066",
@@ -17197,7 +19523,16 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:RIIGIH_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2009-12-20",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32007L0043",
@@ -17228,6 +19563,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:LoKS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2010-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -17259,6 +19603,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1981-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -17326,6 +19674,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -17357,6 +19709,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2014-07-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -17388,6 +19744,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2010-02-28",
+        "@type": "xsd:date"
       }
     },
     {
@@ -17419,6 +19779,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2008-04-05",
+        "@type": "xsd:date"
       }
     },
     {
@@ -17450,6 +19814,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -17548,6 +19916,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-02-13",
+        "@type": "xsd:date"
       }
     },
     {
@@ -17579,6 +19951,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -17615,7 +19991,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2000-12-31",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32011L0090",
@@ -17646,6 +20026,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2012-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -17713,6 +20097,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2001-07-19",
+        "@type": "xsd:date"
       }
     },
     {
@@ -17744,6 +20132,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2005-02-06",
+        "@type": "xsd:date"
       }
     },
     {
@@ -17775,6 +20167,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -17806,6 +20202,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1998-04-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -17878,7 +20278,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2012-07-09",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32005L0031",
@@ -17909,6 +20313,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-05-20",
+        "@type": "xsd:date"
       }
     },
     {
@@ -17945,7 +20353,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2008-05-17",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31998L0098",
@@ -17976,6 +20388,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2000-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -18007,6 +20423,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -18038,6 +20458,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1991-06-27",
+        "@type": "xsd:date"
       }
     },
     {
@@ -18069,6 +20493,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2012-10-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -18100,6 +20528,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -18167,6 +20599,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -18198,6 +20634,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -18234,7 +20674,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1976-11-22",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32004L0086",
@@ -18265,6 +20709,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -18296,6 +20744,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1995-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -18327,6 +20779,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2005-10-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -18358,6 +20814,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1998-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -18389,6 +20849,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1969-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -18425,7 +20889,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2015-01-11",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32012L0026",
@@ -18461,7 +20929,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2013-10-28",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32001L0016",
@@ -18533,7 +21005,16 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:TDRS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2009-12-28",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31989L0398",
@@ -18564,6 +21045,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1990-05-16",
+        "@type": "xsd:date"
       }
     },
     {
@@ -18595,6 +21080,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2000-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -18626,6 +21115,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2015-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -18657,6 +21150,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-11-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -18688,6 +21185,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2015-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -18719,6 +21220,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1984-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -18755,7 +21260,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2013-04-06",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32001L0017",
@@ -18822,6 +21331,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1997-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -18884,6 +21397,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1975-01-27",
+        "@type": "xsd:date"
       }
     },
     {
@@ -18920,7 +21437,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2000-08-10",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32006L0112",
@@ -18951,6 +21472,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2008-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -18987,7 +21512,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1996-12-31",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32006L0048",
@@ -19023,7 +21552,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2006-12-31",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31990L0426",
@@ -19054,6 +21587,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -19085,6 +21622,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -19121,7 +21662,16 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:MERA_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2011-06-30",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32006L0012",
@@ -19188,6 +21738,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1980-12-27",
+        "@type": "xsd:date"
       }
     },
     {
@@ -19219,6 +21773,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -19250,6 +21808,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -19281,6 +21843,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1991-12-21",
+        "@type": "xsd:date"
       }
     },
     {
@@ -19317,7 +21883,16 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:ELTS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2011-03-03",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32014L0054",
@@ -19353,7 +21928,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2016-05-21",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32006L0058",
@@ -19384,6 +21963,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -19420,7 +22003,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2014-06-05",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32010L0076",
@@ -19456,7 +22043,16 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:KREDII_2_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2011-01-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32010L0073",
@@ -19492,7 +22088,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2012-07-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32006L0040",
@@ -19528,7 +22128,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2008-01-03",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31984L0525",
@@ -19559,6 +22163,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1986-03-26",
+        "@type": "xsd:date"
       }
     },
     {
@@ -19595,7 +22203,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2012-11-24",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32005L0077",
@@ -19626,6 +22238,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-04-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -19657,6 +22273,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2000-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -19719,6 +22339,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -19750,6 +22374,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -19781,6 +22409,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1995-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -19812,6 +22444,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -19843,6 +22479,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1981-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -19879,7 +22519,16 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:KOHTUE_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2016-05-23",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31966L0401",
@@ -19910,6 +22559,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1968-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -19946,7 +22599,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1986-06-30",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31991L0157",
@@ -19977,6 +22634,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-09-17",
+        "@type": "xsd:date"
       }
     },
     {
@@ -20044,6 +22705,21 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:MPK_Map_2026"
+        },
+        {
+          "@id": "estleg:TPSKS_Map_2026"
+        },
+        {
+          "@id": "estleg:GMOVS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2010-03-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -20075,6 +22751,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2008-02-02",
+        "@type": "xsd:date"
       }
     },
     {
@@ -20106,6 +22786,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1986-03-26",
+        "@type": "xsd:date"
       }
     },
     {
@@ -20142,7 +22826,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1999-05-28",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32010L0044",
@@ -20173,6 +22861,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -20209,7 +22901,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2008-02-24",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31991L0156",
@@ -20240,6 +22936,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-04-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -20271,6 +22971,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-11-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -20302,6 +23006,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1989-04-16",
+        "@type": "xsd:date"
       }
     },
     {
@@ -20369,6 +23077,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1996-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -20400,6 +23112,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1986-03-26",
+        "@type": "xsd:date"
       }
     },
     {
@@ -20436,7 +23152,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2014-06-02",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32006L0021",
@@ -20472,7 +23192,19 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:Maapueseadus_Map_2026"
+        },
+        {
+          "@id": "estleg:JäätS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2008-05-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31980L0723",
@@ -20503,6 +23235,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1981-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -20539,7 +23275,16 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:RAUDTEE_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2009-06-30",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31976L0767",
@@ -20570,6 +23315,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1978-01-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -20606,7 +23355,16 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:TeeS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2010-12-19",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32008L0006",
@@ -20642,7 +23400,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2010-12-31",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31982L0368",
@@ -20673,6 +23435,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1983-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -20704,6 +23470,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1972-11-25",
+        "@type": "xsd:date"
       }
     },
     {
@@ -20740,7 +23510,16 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:MSOS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2011-06-17",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31987L0344",
@@ -20771,6 +23550,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1990-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -20807,7 +23590,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2017-05-20",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31984L0587",
@@ -20838,6 +23625,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1986-12-03",
+        "@type": "xsd:date"
       }
     },
     {
@@ -20869,6 +23660,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2011-01-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -20900,6 +23700,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2005-05-14",
+        "@type": "xsd:date"
       }
     },
     {
@@ -20931,6 +23735,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1998-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -20967,7 +23775,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2015-03-31",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31985L0391",
@@ -20998,6 +23810,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1986-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -21029,6 +23845,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1991-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -21127,6 +23947,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2003-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -21189,6 +24013,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-03-06",
+        "@type": "xsd:date"
       }
     },
     {
@@ -21220,6 +24048,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1978-10-07",
+        "@type": "xsd:date"
       }
     },
     {
@@ -21282,6 +24114,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -21313,6 +24149,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -21344,6 +24184,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1989-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -21375,6 +24219,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -21406,6 +24254,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:MKS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2011-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -21437,6 +24294,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -21468,6 +24329,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1991-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -21530,6 +24395,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1991-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -21561,6 +24430,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1975-05-22",
+        "@type": "xsd:date"
       }
     },
     {
@@ -21592,6 +24465,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -21623,6 +24500,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1980-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -21654,6 +24535,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -21685,6 +24570,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -21716,6 +24605,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -21752,7 +24645,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2014-02-14",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32002L0100",
@@ -21783,6 +24680,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2003-03-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -21814,6 +24715,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -21845,6 +24750,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1995-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -21881,7 +24790,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2011-12-05",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32008L0055",
@@ -21948,7 +24861,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2000-07-08",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31996L0084",
@@ -21984,7 +24901,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1997-09-30",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31997L0030",
@@ -22015,6 +24936,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1998-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -22046,6 +24971,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2009-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -22082,7 +25011,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2014-12-21",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31999L0021",
@@ -22113,6 +25046,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2000-04-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -22144,6 +25081,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1988-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -22206,6 +25147,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1997-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -22268,6 +25213,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1998-06-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -22299,6 +25248,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1969-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -22330,6 +25283,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-11-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -22397,6 +25354,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -22526,7 +25487,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2006-01-31",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32003L0033",
@@ -22562,7 +25527,16 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:TubS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2005-07-31",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32003L0036",
@@ -22598,7 +25572,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2004-06-25",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32008L0032",
@@ -22670,7 +25648,31 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:MTÜS_Map_2026"
+        },
+        {
+          "@id": "https://data.riik.ee/ontology/estleg#"
+        },
+        {
+          "@id": "estleg:VOS_Osa1_1_207"
+        },
+        {
+          "@id": "estleg:VOS_Osa3_Contract_Obligations_Liability"
+        },
+        {
+          "@id": "estleg:VOS_Osa4_Taitmine_Tasaarvestus_Vabastamine"
+        },
+        {
+          "@id": "estleg:VOS_Osa7_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2011-02-23",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32003L0034",
@@ -22706,7 +25708,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2004-07-15",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32000L0072",
@@ -22737,6 +25743,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2001-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -22768,6 +25778,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1996-02-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -22799,6 +25813,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -22871,7 +25889,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2016-01-18",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32003L0025",
@@ -22907,7 +25929,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2004-11-16",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32001L0084",
@@ -22974,6 +26000,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -23072,6 +26102,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2014-07-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -23108,7 +26142,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2008-04-15",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31988L0411",
@@ -23139,6 +26177,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1988-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -23170,6 +26212,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-03-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -23201,6 +26247,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2008-02-15",
+        "@type": "xsd:date"
       }
     },
     {
@@ -23232,6 +26282,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2008-02-15",
+        "@type": "xsd:date"
       }
     },
     {
@@ -23268,7 +26322,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2014-06-18",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31992L0116",
@@ -23299,6 +26357,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -23330,6 +26392,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1996-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -23361,6 +26427,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2005-01-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -23392,6 +26462,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -23454,6 +26528,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1998-04-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -23485,6 +26563,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1995-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -23547,6 +26629,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-12-18",
+        "@type": "xsd:date"
       }
     },
     {
@@ -23578,6 +26664,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1991-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -23614,7 +26704,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1979-06-15",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32008L0085",
@@ -23645,6 +26739,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2009-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -23676,6 +26779,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2014-07-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -23712,7 +26819,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2005-02-18",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32005L0074",
@@ -23743,6 +26854,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-04-26",
+        "@type": "xsd:date"
       }
     },
     {
@@ -23774,6 +26889,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2003-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -23810,7 +26929,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1997-07-22",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32011L0094",
@@ -23841,6 +26964,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2012-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -23872,6 +26999,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-05-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -23903,6 +27034,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-06-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -23934,6 +27069,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1996-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -23970,7 +27109,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2006-09-09",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32001L0091",
@@ -24032,6 +27175,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-03-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -24068,7 +27215,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2000-05-04",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32015L0653",
@@ -24099,6 +27250,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2017-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -24130,6 +27285,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2005-06-22",
+        "@type": "xsd:date"
       }
     },
     {
@@ -24161,6 +27320,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2015-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -24192,6 +27355,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -24228,7 +27395,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2015-07-19",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31998L0090",
@@ -24259,6 +27430,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1998-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -24295,7 +27470,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2002-08-09",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32007L0006",
@@ -24326,6 +27505,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-07-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -24362,7 +27545,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2016-04-18",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32014L0022",
@@ -24393,6 +27580,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2014-11-15",
+        "@type": "xsd:date"
       }
     },
     {
@@ -24424,6 +27615,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1976-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -24455,6 +27650,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-11-04",
+        "@type": "xsd:date"
       }
     },
     {
@@ -24486,6 +27685,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2009-11-15",
+        "@type": "xsd:date"
       }
     },
     {
@@ -24553,6 +27756,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:VALISM_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2011-06-19",
+        "@type": "xsd:date"
       }
     },
     {
@@ -24589,7 +27801,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1998-09-26",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32014L0021",
@@ -24620,6 +27836,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2015-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -24692,7 +27912,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2016-12-27",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32000L0071",
@@ -24723,6 +27947,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2001-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -24754,6 +27982,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-07-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -24816,6 +28048,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1997-09-16",
+        "@type": "xsd:date"
       }
     },
     {
@@ -24847,6 +28083,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -24878,6 +28118,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2003-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -24909,6 +28153,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1975-12-11",
+        "@type": "xsd:date"
       }
     },
     {
@@ -24940,6 +28188,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-02-28",
+        "@type": "xsd:date"
       }
     },
     {
@@ -24971,6 +28223,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -25038,7 +28294,16 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:VÕKS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2010-06-10",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32005L0070",
@@ -25069,6 +28334,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-04-21",
+        "@type": "xsd:date"
       }
     },
     {
@@ -25100,6 +28369,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-02-24",
+        "@type": "xsd:date"
       }
     },
     {
@@ -25131,6 +28404,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-06-09",
+        "@type": "xsd:date"
       }
     },
     {
@@ -25162,6 +28439,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2003-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -25193,6 +28474,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-07-26",
+        "@type": "xsd:date"
       }
     },
     {
@@ -25224,6 +28509,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-07-27",
+        "@type": "xsd:date"
       }
     },
     {
@@ -25255,6 +28544,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2000-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -25286,6 +28579,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2005-12-04",
+        "@type": "xsd:date"
       }
     },
     {
@@ -25317,6 +28614,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2005-03-25",
+        "@type": "xsd:date"
       }
     },
     {
@@ -25353,7 +28654,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2006-04-19",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32003L0123",
@@ -25384,6 +28689,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2005-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -25415,6 +28724,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1986-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -25477,6 +28790,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2000-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -25508,6 +28825,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-06-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -25539,6 +28860,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1987-10-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -25570,6 +28895,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-11-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -25601,6 +28930,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1995-12-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -25632,6 +28965,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -25699,6 +29036,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2010-01-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -25730,6 +29071,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2008-01-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -25792,6 +29137,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-08-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -25885,6 +29234,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2000-06-29",
+        "@type": "xsd:date"
       }
     },
     {
@@ -25916,6 +29269,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1997-03-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -25947,6 +29304,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-02-16",
+        "@type": "xsd:date"
       }
     },
     {
@@ -25983,7 +29344,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2002-07-19",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32008L0076",
@@ -26014,6 +29379,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2009-04-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -26045,6 +29414,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1984-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -26076,6 +29449,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1990-04-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -26107,6 +29484,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-12-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -26138,6 +29519,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-05-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -26174,7 +29559,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1994-07-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31998L0036",
@@ -26205,6 +29594,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1998-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -26236,6 +29629,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2000-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -26267,6 +29664,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-08-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -26298,6 +29699,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-01-20",
+        "@type": "xsd:date"
       }
     },
     {
@@ -26329,6 +29734,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -26360,6 +29769,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -26391,6 +29804,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-04-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -26422,6 +29839,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1986-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -26453,6 +29874,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2016-07-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -26484,6 +29909,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1996-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -26515,6 +29944,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2001-07-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -26546,6 +29979,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1996-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -26582,7 +30019,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1999-08-05",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31987L0491",
@@ -26613,6 +30054,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1988-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -26708,6 +30153,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-01-29",
+        "@type": "xsd:date"
       }
     },
     {
@@ -26739,6 +30188,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1984-07-15",
+        "@type": "xsd:date"
       }
     },
     {
@@ -26770,6 +30223,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1989-04-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -26801,6 +30258,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-07-19",
+        "@type": "xsd:date"
       }
     },
     {
@@ -26909,7 +30370,16 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:Sadamaseadus_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2002-12-28",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32004L0094",
@@ -26940,6 +30410,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-09-21",
+        "@type": "xsd:date"
       }
     },
     {
@@ -26971,6 +30445,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-10-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -27002,6 +30480,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1997-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -27033,6 +30515,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1984-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -27064,6 +30550,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -27095,6 +30585,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1989-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -27126,6 +30620,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1981-12-26",
+        "@type": "xsd:date"
       }
     },
     {
@@ -27157,6 +30655,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1001-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -27188,6 +30690,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1998-04-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -27219,6 +30725,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2003-04-15",
+        "@type": "xsd:date"
       }
     },
     {
@@ -27250,6 +30760,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1982-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -27312,6 +30826,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-09-23",
+        "@type": "xsd:date"
       }
     },
     {
@@ -27343,6 +30861,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1980-12-22",
+        "@type": "xsd:date"
       }
     },
     {
@@ -27374,6 +30896,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1981-01-26",
+        "@type": "xsd:date"
       }
     },
     {
@@ -27436,6 +30962,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -27467,6 +30997,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -27498,6 +31032,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1985-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -27529,6 +31067,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1986-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -27560,6 +31102,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1991-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -27591,6 +31137,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1979-07-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -27622,6 +31172,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-09-11",
+        "@type": "xsd:date"
       }
     },
     {
@@ -27684,6 +31238,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2000-06-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -27715,6 +31273,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1984-06-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -27746,6 +31308,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2008-10-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -27777,6 +31348,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2008-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -27849,7 +31429,16 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:TFS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2010-12-31",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31987L0181",
@@ -27880,6 +31469,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1988-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -27911,6 +31504,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1989-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -27942,6 +31539,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1988-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -27973,6 +31574,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-07-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -28004,6 +31609,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2009-01-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -28035,6 +31649,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-12-19",
+        "@type": "xsd:date"
       }
     },
     {
@@ -28066,6 +31684,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1986-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -28128,6 +31750,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2000-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -28159,6 +31785,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2002-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -28190,6 +31820,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2008-10-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -28221,6 +31860,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1002-02-02",
+        "@type": "xsd:date"
       }
     },
     {
@@ -28252,6 +31895,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2000-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -28283,6 +31930,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-09-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -28314,6 +31965,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2015-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -28376,6 +32031,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1976-11-21",
+        "@type": "xsd:date"
       }
     },
     {
@@ -28407,6 +32066,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -28438,6 +32101,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2016-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -28469,6 +32136,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2014-07-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -28500,6 +32171,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1996-09-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -28531,6 +32206,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1979-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -28562,6 +32241,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-09-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -28593,6 +32276,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2013-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -28624,6 +32311,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1980-01-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -28655,6 +32346,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2014-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -28686,6 +32381,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-11-19",
+        "@type": "xsd:date"
       }
     },
     {
@@ -28717,6 +32416,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2010-04-15",
+        "@type": "xsd:date"
       }
     },
     {
@@ -28753,7 +32456,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2001-08-09",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31970L0050",
@@ -28815,6 +32522,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1971-12-09",
+        "@type": "xsd:date"
       }
     },
     {
@@ -28846,6 +32557,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -28877,6 +32592,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1977-06-17",
+        "@type": "xsd:date"
       }
     },
     {
@@ -28908,6 +32627,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1991-04-17",
+        "@type": "xsd:date"
       }
     },
     {
@@ -28939,6 +32662,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1989-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -28974,6 +32701,23 @@
         },
         {
           "@id": "estleg:EUInst_EuropeanParliament"
+        }
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "https://data.riik.ee/ontology/estleg#"
+        },
+        {
+          "@id": "estleg:VOS_Osa1_1_207"
+        },
+        {
+          "@id": "estleg:VOS_Osa3_Contract_Obligations_Liability"
+        },
+        {
+          "@id": "estleg:VOS_Osa4_Taitmine_Tasaarvestus_Vabastamine"
+        },
+        {
+          "@id": "estleg:VOS_Osa7_Map_2026"
         }
       ]
     },
@@ -29042,6 +32786,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1998-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -29073,6 +32821,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1996-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -29140,6 +32892,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2016-10-29",
+        "@type": "xsd:date"
       }
     },
     {
@@ -29171,6 +32927,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -29202,6 +32962,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2005-07-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -29233,6 +32997,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-05-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -29264,6 +33032,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:KOKS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2013-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -29300,7 +33077,16 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:TUK_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2011-06-05",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31995L0043",
@@ -29331,6 +33117,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1995-10-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -29362,6 +33152,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2009-03-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -29393,6 +33192,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:TLS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1998-06-03",
+        "@type": "xsd:date"
       }
     },
     {
@@ -29424,6 +33232,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2005-01-29",
+        "@type": "xsd:date"
       }
     },
     {
@@ -29455,6 +33267,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1996-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -29486,6 +33302,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2015-07-20",
+        "@type": "xsd:date"
       }
     },
     {
@@ -29553,7 +33373,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1996-09-24",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32003L0114",
@@ -29589,7 +33413,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2005-07-27",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31992L0053",
@@ -29620,6 +33448,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -29651,6 +33483,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1971-12-09",
+        "@type": "xsd:date"
       }
     },
     {
@@ -29682,6 +33518,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2010-10-12",
+        "@type": "xsd:date"
       }
     },
     {
@@ -29713,6 +33553,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:MKS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2013-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -29749,7 +33598,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1997-12-19",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31994L0004",
@@ -29780,6 +33633,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-04-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -29816,7 +33673,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2008-02-15",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31996L0085",
@@ -29852,7 +33713,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1997-06-28",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32012L0018",
@@ -29888,7 +33753,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2015-05-31",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32010L0048",
@@ -29919,6 +33788,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -29950,6 +33823,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2003-09-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -29981,6 +33858,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1998-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -30012,6 +33893,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1997-03-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -30043,6 +33928,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1995-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -30074,6 +33963,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1998-03-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -30105,6 +33998,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2012-03-08",
+        "@type": "xsd:date"
       }
     },
     {
@@ -30136,6 +34033,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-11-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -30198,6 +34099,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1979-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -30229,6 +34134,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:STRATE_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2011-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -30296,6 +34210,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1980-04-23",
+        "@type": "xsd:date"
       }
     },
     {
@@ -30327,6 +34245,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1997-04-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -30363,7 +34285,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1983-10-23",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31999L0018",
@@ -30394,6 +34320,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-10-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -30425,6 +34355,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1998-05-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -30487,6 +34421,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -30577,6 +34515,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -30608,6 +34550,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -30639,6 +34585,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1981-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -30670,6 +34620,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-09-05",
+        "@type": "xsd:date"
       }
     },
     {
@@ -30706,7 +34660,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1992-07-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32000L0051",
@@ -30737,6 +34695,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2001-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -30768,6 +34730,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-08-18",
+        "@type": "xsd:date"
       }
     },
     {
@@ -30799,6 +34765,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1997-12-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -30830,6 +34800,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1990-09-29",
+        "@type": "xsd:date"
       }
     },
     {
@@ -30861,6 +34835,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-06-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -30892,6 +34870,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1996-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -30959,6 +34941,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -30990,6 +34976,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2008-08-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -31021,6 +35011,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1974-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -31052,6 +35046,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -31083,6 +35081,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -31155,7 +35157,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1999-08-14",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32003L0071",
@@ -31191,7 +35197,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2005-07-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32010L0012",
@@ -31222,6 +35232,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:ATKE_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2011-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -31253,6 +35272,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1981-11-04",
+        "@type": "xsd:date"
       }
     },
     {
@@ -31284,6 +35307,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2014-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -31320,7 +35347,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2001-07-03",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32000L0028",
@@ -31356,7 +35387,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2002-04-27",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31993L0005",
@@ -31387,6 +35422,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-05-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -31418,6 +35457,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1978-07-26",
+        "@type": "xsd:date"
       }
     },
     {
@@ -31449,6 +35492,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1996-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -31511,6 +35558,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -31542,6 +35593,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:Sadamaseadus_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2009-06-15",
+        "@type": "xsd:date"
       }
     },
     {
@@ -31573,6 +35633,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1987-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -31609,7 +35673,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2004-04-12",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31990L0207",
@@ -31640,6 +35708,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1990-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -31671,6 +35743,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1997-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -31702,6 +35778,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-07-04",
+        "@type": "xsd:date"
       }
     },
     {
@@ -31738,7 +35818,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2002-01-16",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31994L0032",
@@ -31769,6 +35853,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1995-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -31837,7 +35925,28 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "https://data.riik.ee/ontology/estleg#"
+        },
+        {
+          "@id": "estleg:VOS_Osa1_1_207"
+        },
+        {
+          "@id": "estleg:VOS_Osa3_Contract_Obligations_Liability"
+        },
+        {
+          "@id": "estleg:VOS_Osa4_Taitmine_Tasaarvestus_Vabastamine"
+        },
+        {
+          "@id": "estleg:VOS_Osa7_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2002-01-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31994L0047",
@@ -31873,7 +35982,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1997-04-29",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31978L1033",
@@ -31904,6 +36017,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1979-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -31935,6 +36052,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2016-12-09",
+        "@type": "xsd:date"
       }
     },
     {
@@ -31966,6 +36087,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2000-04-07",
+        "@type": "xsd:date"
       }
     },
     {
@@ -31997,6 +36122,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2009-03-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -32064,6 +36198,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-07-24",
+        "@type": "xsd:date"
       }
     },
     {
@@ -32095,6 +36233,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -32126,6 +36268,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2003-03-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -32157,6 +36303,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1975-05-26",
+        "@type": "xsd:date"
       }
     },
     {
@@ -32188,6 +36338,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-03-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -32219,6 +36373,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -32250,6 +36408,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2001-02-27",
+        "@type": "xsd:date"
       }
     },
     {
@@ -32281,6 +36443,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-07-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -32317,7 +36483,11 @@
         {
           "@id": "estleg:EUInst_DG03"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1962-11-26",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31978L0387",
@@ -32348,6 +36518,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1980-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -32379,6 +36553,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1979-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -32410,6 +36588,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -32441,6 +36623,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -32472,6 +36658,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2003-10-10",
+        "@type": "xsd:date"
       }
     },
     {
@@ -32503,6 +36693,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-12-12",
+        "@type": "xsd:date"
       }
     },
     {
@@ -32534,6 +36728,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2013-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -32565,6 +36763,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-06-29",
+        "@type": "xsd:date"
       }
     },
     {
@@ -32596,6 +36798,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2001-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -32632,7 +36838,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2004-01-16",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32008L0119",
@@ -32663,6 +36873,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -32694,6 +36908,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-03-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -32725,6 +36943,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2002-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -32756,6 +36978,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1995-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -32787,6 +37013,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1995-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -32818,6 +37048,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2000-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -32849,6 +37083,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1987-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -32911,6 +37149,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-04-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -32942,6 +37184,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1984-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -32973,6 +37219,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2010-10-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -33004,6 +37254,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1988-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -33035,6 +37289,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1983-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -33066,6 +37324,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1979-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -33097,6 +37359,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2013-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -33128,6 +37394,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1975-12-10",
+        "@type": "xsd:date"
       }
     },
     {
@@ -33159,6 +37429,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -33231,7 +37505,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1995-07-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31974L0152",
@@ -33262,6 +37540,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1975-09-06",
+        "@type": "xsd:date"
       }
     },
     {
@@ -33329,6 +37611,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1980-01-29",
+        "@type": "xsd:date"
       }
     },
     {
@@ -33360,6 +37646,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2013-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -33396,7 +37686,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1997-03-31",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31972L0245",
@@ -33427,6 +37721,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1973-12-22",
+        "@type": "xsd:date"
       }
     },
     {
@@ -33458,6 +37756,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2010-02-28",
+        "@type": "xsd:date"
       }
     },
     {
@@ -33489,6 +37791,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1986-10-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -33520,6 +37826,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2013-12-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -33551,6 +37861,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -33582,6 +37896,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-03-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -33613,6 +37931,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2008-04-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -33644,6 +37966,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1975-09-06",
+        "@type": "xsd:date"
       }
     },
     {
@@ -33675,6 +38001,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1988-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -33706,6 +38036,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1990-09-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -33737,6 +38071,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1971-08-10",
+        "@type": "xsd:date"
       }
     },
     {
@@ -33768,6 +38106,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-12-14",
+        "@type": "xsd:date"
       }
     },
     {
@@ -33799,6 +38141,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1978-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -33830,6 +38176,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1997-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -33861,6 +38211,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1972-09-04",
+        "@type": "xsd:date"
       }
     },
     {
@@ -33892,6 +38246,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1981-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -33923,6 +38281,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1997-02-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -33959,7 +38321,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1981-10-13",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31970L0311",
@@ -33990,6 +38356,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1971-12-11",
+        "@type": "xsd:date"
       }
     },
     {
@@ -34021,6 +38391,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-04-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -34083,6 +38457,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -34114,6 +38492,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2016-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -34150,7 +38532,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1998-07-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31995L0006",
@@ -34181,6 +38567,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1995-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -34212,6 +38602,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -34243,6 +38637,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-11-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -34274,6 +38672,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-10-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -34305,6 +38707,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -34336,6 +38742,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -34367,6 +38777,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1976-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -34398,6 +38812,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1977-01-19",
+        "@type": "xsd:date"
       }
     },
     {
@@ -34429,6 +38847,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1997-12-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -34460,6 +38882,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1997-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -34491,6 +38917,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2005-04-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -34527,7 +38957,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2013-06-10",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31988L0301",
@@ -34589,6 +39023,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1996-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -34620,6 +39058,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -34651,6 +39093,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1998-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -34682,6 +39128,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2012-01-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -34713,6 +39168,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -34744,6 +39203,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -34806,6 +39269,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-10-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -34837,6 +39304,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-03-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -34868,6 +39339,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -34899,6 +39374,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -34930,6 +39409,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -34961,6 +39444,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1986-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -34992,6 +39479,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2008-07-05",
+        "@type": "xsd:date"
       }
     },
     {
@@ -35059,6 +39550,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2003-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -35090,6 +39585,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1995-08-08",
+        "@type": "xsd:date"
       }
     },
     {
@@ -35250,6 +39749,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1986-03-20",
+        "@type": "xsd:date"
       }
     },
     {
@@ -35281,6 +39784,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2000-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -35353,7 +39860,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2003-12-31",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31984L0569",
@@ -35446,6 +39957,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2008-02-02",
+        "@type": "xsd:date"
       }
     },
     {
@@ -35482,7 +39997,16 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:RAAMAT_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2011-01-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31988L0490",
@@ -35513,6 +40037,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1990-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -35549,7 +40077,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2005-01-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32015L2302",
@@ -35585,7 +40117,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2018-01-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31997L0024R11",
@@ -35648,6 +40184,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1987-08-05",
+        "@type": "xsd:date"
       }
     },
     {
@@ -35679,6 +40219,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:KREDII_2_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2010-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -35715,7 +40264,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1001-01-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32009L0109",
@@ -35751,7 +40304,31 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:VPTS_Map_2026"
+        },
+        {
+          "@id": "estleg:MERA_Map_2026"
+        },
+        {
+          "@id": "estleg:KREDII_2_Map_2026"
+        },
+        {
+          "@id": "estleg:riseadustik1_Map_2026"
+        },
+        {
+          "@id": "estleg:KINDLU_Map_2026"
+        },
+        {
+          "@id": "estleg:INVEST_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2011-06-30",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32001L0043",
@@ -35818,6 +40395,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1988-03-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -35849,6 +40430,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1978-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -35885,7 +40470,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2000-06-30",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31987L0480",
@@ -35916,6 +40505,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1987-09-10",
+        "@type": "xsd:date"
       }
     },
     {
@@ -35947,6 +40540,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-12-14",
+        "@type": "xsd:date"
       }
     },
     {
@@ -35978,6 +40575,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2003-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -36009,6 +40610,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1989-10-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -36045,7 +40650,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1981-11-06",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31997L0028",
@@ -36076,6 +40685,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1998-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -36112,7 +40725,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2006-08-25",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31970L0222",
@@ -36143,6 +40760,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1971-10-07",
+        "@type": "xsd:date"
       }
     },
     {
@@ -36174,6 +40795,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1989-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -36210,7 +40835,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2014-07-07",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31970L0387",
@@ -36241,6 +40870,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1972-01-28",
+        "@type": "xsd:date"
       }
     },
     {
@@ -36272,6 +40905,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -36308,7 +40945,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2013-10-28",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32002L0080",
@@ -36339,6 +40980,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2003-05-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -36370,6 +41015,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -36401,6 +41050,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-03-08",
+        "@type": "xsd:date"
       }
     },
     {
@@ -36432,6 +41085,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1998-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -36463,6 +41120,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2000-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -36525,6 +41186,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1988-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -36556,6 +41221,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1988-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -36592,7 +41261,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1997-04-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31973L0350",
@@ -36623,6 +41296,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1002-02-02",
+        "@type": "xsd:date"
       }
     },
     {
@@ -36654,6 +41331,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1978-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -36685,6 +41366,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1998-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -36716,6 +41401,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2005-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -36747,6 +41436,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2001-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -36778,6 +41471,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2012-01-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -36809,6 +41506,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1972-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -36840,6 +41541,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -36871,6 +41576,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1989-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -36934,6 +41643,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1002-02-02",
+        "@type": "xsd:date"
       }
     },
     {
@@ -36996,6 +41709,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2005-04-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -37058,6 +41775,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-11-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -37089,6 +41810,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-03-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -37120,6 +41845,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2017-05-24",
+        "@type": "xsd:date"
       }
     },
     {
@@ -37151,6 +41880,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-07-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -37182,6 +41915,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-09-18",
+        "@type": "xsd:date"
       }
     },
     {
@@ -37213,6 +41950,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1976-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -37244,6 +41985,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -37275,6 +42020,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1997-03-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -37306,6 +42055,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -37337,6 +42090,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2002-07-02",
+        "@type": "xsd:date"
       }
     },
     {
@@ -37368,6 +42125,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -37435,7 +42196,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2008-01-23",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32009L0010",
@@ -37466,6 +42231,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2010-02-13",
+        "@type": "xsd:date"
       }
     },
     {
@@ -37497,6 +42266,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2008-05-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -37528,6 +42301,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -37559,6 +42336,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1991-01-02",
+        "@type": "xsd:date"
       }
     },
     {
@@ -37590,6 +42371,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -37621,6 +42406,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-03-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -37657,7 +42446,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2008-08-06",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32006L0077",
@@ -37688,6 +42481,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-10-20",
+        "@type": "xsd:date"
       }
     },
     {
@@ -37719,6 +42516,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1979-12-03",
+        "@type": "xsd:date"
       }
     },
     {
@@ -37750,6 +42551,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1997-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -37781,6 +42586,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2010-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -37812,6 +42626,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-08-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -37874,6 +42692,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -37905,6 +42727,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2008-03-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -37936,6 +42762,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1977-12-19",
+        "@type": "xsd:date"
       }
     },
     {
@@ -37972,7 +42802,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2000-04-23",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32001L0109",
@@ -38039,6 +42873,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1981-10-13",
+        "@type": "xsd:date"
       }
     },
     {
@@ -38070,6 +42908,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1987-10-17",
+        "@type": "xsd:date"
       }
     },
     {
@@ -38106,7 +42948,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2000-06-05",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31973L0046",
@@ -38137,6 +42983,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1974-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -38168,6 +43018,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1986-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -38199,6 +43053,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1997-11-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -38261,6 +43119,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1991-04-08",
+        "@type": "xsd:date"
       }
     },
     {
@@ -38292,6 +43154,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-02-28",
+        "@type": "xsd:date"
       }
     },
     {
@@ -38323,6 +43189,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-07-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -38354,6 +43224,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2009-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -38421,6 +43295,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2008-03-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -38483,6 +43361,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2005-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -38514,6 +43396,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-04-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -38545,6 +43431,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1995-07-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -38576,6 +43466,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-03-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -38607,6 +43501,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2010-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -38643,7 +43541,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1998-06-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32010L0042",
@@ -38674,6 +43576,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2010-10-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -38705,6 +43611,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2009-08-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -38736,6 +43646,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -38767,6 +43681,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2010-02-28",
+        "@type": "xsd:date"
       }
     },
     {
@@ -38798,6 +43716,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-08-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -38860,6 +43782,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -38891,6 +43817,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -38922,6 +43852,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2009-10-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -38953,6 +43887,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2015-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -38984,6 +43922,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-03-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -39046,6 +43988,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2009-01-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -39108,6 +44054,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1990-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -39139,6 +44089,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2009-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -39201,6 +44155,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2008-08-05",
+        "@type": "xsd:date"
       }
     },
     {
@@ -39263,6 +44221,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2005-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -39294,6 +44256,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2010-07-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -39356,6 +44322,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-04-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -39392,7 +44362,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2000-01-20",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32003L0030",
@@ -39428,7 +44402,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2004-12-31",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31974L0061",
@@ -39459,6 +44437,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1975-06-20",
+        "@type": "xsd:date"
       }
     },
     {
@@ -39517,6 +44499,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -39553,7 +44539,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2006-04-19",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31980L0891",
@@ -39615,6 +44605,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -39646,6 +44640,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1996-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -39677,6 +44675,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1977-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -39708,6 +44710,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -39739,6 +44745,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2014-07-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -39770,6 +44780,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2008-02-29",
+        "@type": "xsd:date"
       }
     },
     {
@@ -39801,6 +44820,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-12-14",
+        "@type": "xsd:date"
       }
     },
     {
@@ -39832,6 +44855,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2014-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -39863,6 +44890,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1984-10-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -39894,6 +44925,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1979-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -39925,6 +44960,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1982-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -39956,6 +44995,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1988-06-02",
+        "@type": "xsd:date"
       }
     },
     {
@@ -39992,7 +45035,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1999-09-28",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31983L0276",
@@ -40023,6 +45070,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1983-10-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -40054,6 +45105,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1975-03-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -40090,7 +45145,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2006-04-19",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31999L0040",
@@ -40121,6 +45180,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2000-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -40152,6 +45215,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-06-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -40183,6 +45250,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1976-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -40214,6 +45285,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-05-28",
+        "@type": "xsd:date"
       }
     },
     {
@@ -40276,6 +45351,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2007-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -40312,7 +45396,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2007-09-15",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32004L0001",
@@ -40343,6 +45431,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2005-08-02",
+        "@type": "xsd:date"
       }
     },
     {
@@ -40415,7 +45507,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2013-06-30",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32011L0046",
@@ -40446,6 +45542,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-11-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -40477,6 +45577,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1975-04-18",
+        "@type": "xsd:date"
       }
     },
     {
@@ -40508,6 +45612,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1988-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -40539,6 +45647,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-05-10",
+        "@type": "xsd:date"
       }
     },
     {
@@ -40570,6 +45682,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2014-04-10",
+        "@type": "xsd:date"
       }
     },
     {
@@ -40601,6 +45717,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-01-09",
+        "@type": "xsd:date"
       }
     },
     {
@@ -40632,6 +45752,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2003-08-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -40668,7 +45792,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2009-01-16",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32014L0056",
@@ -40704,7 +45832,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2016-06-17",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31968L0297",
@@ -40771,7 +45903,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2000-03-18",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31996L0074R02",
@@ -40865,6 +46001,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-09-29",
+        "@type": "xsd:date"
       }
     },
     {
@@ -40896,6 +46036,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1978-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -40932,7 +46076,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2007-12-27",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31980L0049",
@@ -40963,6 +46111,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1980-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -40994,6 +46146,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1979-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -41025,6 +46181,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1987-08-05",
+        "@type": "xsd:date"
       }
     },
     {
@@ -41056,6 +46216,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1989-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -41087,6 +46251,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2009-03-19",
+        "@type": "xsd:date"
       }
     },
     {
@@ -41118,6 +46286,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2015-04-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -41154,7 +46326,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2003-04-30",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31991L0334",
@@ -41185,6 +46361,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-01-22",
+        "@type": "xsd:date"
       }
     },
     {
@@ -41216,6 +46396,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1988-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -41247,6 +46431,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -41278,6 +46466,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -41309,6 +46501,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-10-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -41340,6 +46536,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1997-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -41371,6 +46571,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1990-07-10",
+        "@type": "xsd:date"
       }
     },
     {
@@ -41407,7 +46611,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1995-12-31",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31974L0483",
@@ -41438,6 +46646,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1975-06-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -41469,6 +46681,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-03-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -41500,6 +46716,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1984-07-13",
+        "@type": "xsd:date"
       }
     },
     {
@@ -41531,6 +46751,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -41562,6 +46786,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2016-07-11",
+        "@type": "xsd:date"
       }
     },
     {
@@ -41593,6 +46821,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2008-04-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -41624,6 +46856,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2000-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -41655,6 +46891,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1975-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -41686,6 +46926,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1983-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -41717,6 +46961,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1998-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -41748,6 +46996,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -41779,6 +47031,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1996-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -41810,6 +47066,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2000-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -41841,6 +47101,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2000-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -41872,6 +47136,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1998-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -41903,6 +47171,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-08-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -41934,6 +47206,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2012-01-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -41965,6 +47246,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1984-02-15",
+        "@type": "xsd:date"
       }
     },
     {
@@ -41996,6 +47281,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1973-01-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -42027,6 +47316,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1996-04-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -42058,6 +47351,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-09-29",
+        "@type": "xsd:date"
       }
     },
     {
@@ -42089,6 +47386,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2003-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -42120,6 +47421,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2010-08-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -42151,6 +47456,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-11-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -42187,7 +47496,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2006-07-16",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31993L0072",
@@ -42218,6 +47531,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -42249,6 +47566,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2009-03-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -42280,6 +47601,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -42342,6 +47667,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1989-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -42373,6 +47702,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -42404,6 +47737,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2010-01-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -42435,6 +47772,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2010-02-28",
+        "@type": "xsd:date"
       }
     },
     {
@@ -42466,6 +47807,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2008-03-18",
+        "@type": "xsd:date"
       }
     },
     {
@@ -42497,6 +47842,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -42528,6 +47877,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:LIIKLU_2_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2009-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -42559,6 +47917,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2010-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -42590,6 +47952,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2010-11-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -42621,6 +47987,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-10-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -42652,6 +48022,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2002-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -42683,6 +48057,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-11-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -42745,6 +48123,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2001-10-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -42781,7 +48163,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2005-10-30",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32010L0047",
@@ -42812,6 +48198,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2012-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -42843,6 +48233,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1988-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -42874,6 +48268,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2000-05-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -42905,6 +48303,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1981-01-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -42941,7 +48343,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2005-01-25",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31999L0092",
@@ -42977,7 +48383,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2003-06-30",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31978L0052",
@@ -43008,6 +48418,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1978-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -43039,6 +48453,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -43070,6 +48488,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2013-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -43101,6 +48523,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -43132,6 +48558,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2009-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -43168,7 +48603,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1997-10-28",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31988L0506",
@@ -43235,7 +48674,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2017-10-10",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32003L0105",
@@ -43271,7 +48714,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2005-06-30",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32000L0018",
@@ -43307,7 +48754,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2000-05-19",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31996L0043",
@@ -43338,6 +48789,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1996-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -43369,6 +48824,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-10-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -43432,6 +48891,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2008-03-18",
+        "@type": "xsd:date"
       }
     },
     {
@@ -43463,6 +48926,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2010-09-15",
+        "@type": "xsd:date"
       }
     },
     {
@@ -43494,6 +48961,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1983-05-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -43525,6 +48996,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1996-05-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -43556,6 +49031,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1979-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -43587,6 +49066,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2010-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -43623,7 +49111,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2004-11-16",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31996L0037",
@@ -43654,6 +49146,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1996-12-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -43685,6 +49181,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1983-11-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -43716,6 +49216,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1989-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -43752,7 +49256,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2006-05-08",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31985L0205",
@@ -43783,6 +49291,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1985-10-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -43814,6 +49326,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1990-04-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -43845,6 +49361,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2001-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -43876,6 +49396,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-05-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -43907,6 +49431,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -43974,7 +49502,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2000-09-28",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32001L0007",
@@ -44036,6 +49568,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1980-11-21",
+        "@type": "xsd:date"
       }
     },
     {
@@ -44067,6 +49603,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1995-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -44129,6 +49669,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1985-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -44160,6 +49704,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1998-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -44191,6 +49739,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2009-08-03",
+        "@type": "xsd:date"
       }
     },
     {
@@ -44222,6 +49774,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-03-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -44258,7 +49814,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2016-07-03",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31995L0001",
@@ -44294,7 +49854,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1996-08-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32003L0053",
@@ -44330,7 +49894,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2004-07-16",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32004L0048",
@@ -44366,7 +49934,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2006-04-29",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32015L2117",
@@ -44397,6 +49969,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2017-11-24",
+        "@type": "xsd:date"
       }
     },
     {
@@ -44428,6 +50004,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2005-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -44490,6 +50070,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2000-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -44521,6 +50105,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-01-29",
+        "@type": "xsd:date"
       }
     },
     {
@@ -44552,6 +50140,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1997-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -44588,7 +50180,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2001-07-30",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31993L0087",
@@ -44650,6 +50246,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1984-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -44681,6 +50281,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1989-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -44712,6 +50316,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1977-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -44748,7 +50356,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2018-11-27",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31999L0103",
@@ -44784,7 +50396,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2001-02-08",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32007L0016",
@@ -44815,6 +50431,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2008-03-23",
+        "@type": "xsd:date"
       }
     },
     {
@@ -44846,6 +50466,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2011-09-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -44877,6 +50506,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1991-04-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -44908,6 +50541,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2000-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -44939,6 +50576,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2010-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -44970,6 +50616,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1976-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -45006,7 +50656,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2004-12-31",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32006L0119",
@@ -45037,6 +50691,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -45068,6 +50726,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1991-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -45104,7 +50766,16 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:TNV_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2011-06-20",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31985L0346",
@@ -45135,6 +50806,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1985-10-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -45202,6 +50877,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1988-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -45233,6 +50912,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1995-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -45264,6 +50947,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1989-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -45295,6 +50982,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -45326,6 +51017,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1983-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -45357,6 +51052,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-10-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -45393,7 +51092,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2001-05-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32007L0024",
@@ -45460,6 +51163,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1972-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -45522,6 +51229,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-01-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -45553,6 +51264,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1979-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -45584,6 +51299,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2012-04-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -45615,6 +51339,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2005-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -45646,6 +51374,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -45677,6 +51409,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -45708,6 +51444,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1983-10-14",
+        "@type": "xsd:date"
       }
     },
     {
@@ -45739,6 +51479,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-09-15",
+        "@type": "xsd:date"
       }
     },
     {
@@ -45770,6 +51514,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-10-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -45801,6 +51549,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1985-10-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -45864,6 +51616,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1973-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -45900,7 +51656,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2001-12-29",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31995L0013",
@@ -45931,6 +51691,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1996-03-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -45962,6 +51726,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-04-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -45993,6 +51761,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1997-07-15",
+        "@type": "xsd:date"
       }
     },
     {
@@ -46024,6 +51796,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -46060,7 +51836,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2004-08-10",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31983L0572",
@@ -46091,6 +51871,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1984-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -46127,7 +51911,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1998-12-31",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32006L0044",
@@ -46194,6 +51982,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -46230,7 +52022,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2011-01-20",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32014L0108",
@@ -46261,6 +52057,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2015-03-16",
+        "@type": "xsd:date"
       }
     },
     {
@@ -46292,6 +52092,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2009-04-05",
+        "@type": "xsd:date"
       }
     },
     {
@@ -46323,6 +52127,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-11-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -46354,6 +52162,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-11-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -46385,6 +52197,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2012-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -46416,6 +52232,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2013-03-15",
+        "@type": "xsd:date"
       }
     },
     {
@@ -46452,7 +52272,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2005-01-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31982L0711",
@@ -46550,7 +52374,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2006-12-15",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31985L0610",
@@ -46581,6 +52409,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1987-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -46612,6 +52444,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-11-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -46643,6 +52479,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1975-09-06",
+        "@type": "xsd:date"
       }
     },
     {
@@ -46674,6 +52514,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2017-08-15",
+        "@type": "xsd:date"
       }
     },
     {
@@ -46705,6 +52549,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1981-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -46741,7 +52589,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2007-02-15",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31992L0089",
@@ -46772,6 +52624,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-10-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -46834,6 +52690,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2018-05-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -46865,6 +52725,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1998-06-15",
+        "@type": "xsd:date"
       }
     },
     {
@@ -46901,7 +52765,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1995-06-20",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32007L0027R01",
@@ -46995,6 +52863,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2016-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -47093,6 +52965,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -47129,7 +53005,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1995-07-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31999L0095",
@@ -47165,7 +53045,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2002-06-30",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31990L0088",
@@ -47196,6 +53080,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -47227,6 +53115,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-01-06",
+        "@type": "xsd:date"
       }
     },
     {
@@ -47263,7 +53155,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1988-06-30",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31999L0101",
@@ -47294,6 +53190,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2000-03-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -47325,6 +53225,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1988-05-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -47356,6 +53260,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1996-02-12",
+        "@type": "xsd:date"
       }
     },
     {
@@ -47423,7 +53331,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2006-12-15",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31973L0438",
@@ -47454,6 +53366,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1973-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -47485,6 +53401,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2014-07-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -47521,7 +53441,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1995-12-07",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32014L0094",
@@ -47557,7 +53481,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2016-11-18",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32002L0035",
@@ -47619,6 +53547,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1990-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -47655,7 +53587,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2001-10-28",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31993L0079",
@@ -47686,6 +53622,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -47748,6 +53688,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2015-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -47779,6 +53723,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1998-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -47841,6 +53789,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-11-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -47872,6 +53824,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-03-11",
+        "@type": "xsd:date"
       }
     },
     {
@@ -47908,7 +53864,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2006-11-05",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31997L0076",
@@ -47939,6 +53899,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1998-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -48006,6 +53970,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2010-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -48037,6 +54005,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1998-12-04",
+        "@type": "xsd:date"
       }
     },
     {
@@ -48068,6 +54040,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1990-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -48135,7 +54111,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2004-02-15",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32006L0084",
@@ -48166,6 +54146,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -48202,7 +54186,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1995-11-30",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32009L0134",
@@ -48233,6 +54221,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2010-05-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -48264,6 +54256,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2005-03-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -48295,6 +54291,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-10-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -48357,6 +54357,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -48388,6 +54392,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1001-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -48450,6 +54458,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1986-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -48481,6 +54493,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1985-10-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -48512,6 +54528,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1972-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -48543,6 +54563,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-02-28",
+        "@type": "xsd:date"
       }
     },
     {
@@ -48574,6 +54598,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1988-10-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -48605,6 +54633,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2015-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -48636,6 +54668,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:FIS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2016-07-03",
+        "@type": "xsd:date"
       }
     },
     {
@@ -48667,6 +54708,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1964-08-26",
+        "@type": "xsd:date"
       }
     },
     {
@@ -48698,6 +54743,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2003-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -48760,6 +54809,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1998-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -48796,7 +54849,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2016-04-19",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31994L0011",
@@ -48832,7 +54889,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1995-09-23",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32015L2366",
@@ -48868,7 +54929,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2018-01-13",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31997L0043",
@@ -48899,6 +54964,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2000-05-12",
+        "@type": "xsd:date"
       }
     },
     {
@@ -48930,6 +54999,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2014-09-20",
+        "@type": "xsd:date"
       }
     },
     {
@@ -48961,6 +55034,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2000-02-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -48992,6 +55069,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2015-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -49059,6 +55140,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2005-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -49090,6 +55175,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -49153,6 +55242,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1995-05-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -49184,6 +55277,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1972-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -49246,6 +55343,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2005-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -49339,6 +55440,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -49375,7 +55480,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2007-10-20",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31997L0010",
@@ -49406,6 +55515,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1997-12-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -49442,7 +55555,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2002-11-17",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32001L0026",
@@ -49509,6 +55626,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1984-06-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -49540,6 +55661,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -49612,7 +55737,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2012-12-09",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31978L0663",
@@ -49643,6 +55772,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1980-01-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -49674,6 +55807,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2005-05-14",
+        "@type": "xsd:date"
       }
     },
     {
@@ -49705,6 +55842,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1998-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -49736,6 +55877,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-09-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -49767,6 +55912,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1982-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -49860,6 +56009,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -49891,6 +56044,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1991-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -49922,6 +56079,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2008-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -49958,7 +56119,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2007-01-31",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31982L0893",
@@ -49989,6 +56154,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1983-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -50020,6 +56189,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-11-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -50051,6 +56224,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1987-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -50082,6 +56259,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:KIIRGU_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2008-12-24",
+        "@type": "xsd:date"
       }
     },
     {
@@ -50113,6 +56299,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2014-02-28",
+        "@type": "xsd:date"
       }
     },
     {
@@ -50144,6 +56334,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2003-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -50175,6 +56369,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2015-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -50233,6 +56431,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2013-04-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -50264,6 +56471,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2014-01-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -50300,7 +56516,16 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2010-05-14",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32010L0072",
@@ -50331,6 +56556,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2011-10-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -50362,6 +56596,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2010-02-03",
+        "@type": "xsd:date"
       }
     },
     {
@@ -50398,7 +56636,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2017-05-22",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31974L0149",
@@ -50460,6 +56702,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1988-10-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -50496,7 +56742,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1999-02-16",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32013L0023",
@@ -50527,6 +56777,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:KREDII_2_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2013-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -50558,6 +56817,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-11-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -50589,6 +56852,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1991-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -50620,6 +56887,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1983-05-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -50651,6 +56922,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2013-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -50682,6 +56957,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1975-06-20",
+        "@type": "xsd:date"
       }
     },
     {
@@ -50713,6 +56992,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2001-04-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -50744,6 +57027,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2003-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -50775,6 +57062,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2010-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -50806,6 +57097,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-02-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -50837,6 +57132,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-11-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -50909,7 +57208,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2016-04-10",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32007L0028",
@@ -50940,6 +57243,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-11-26",
+        "@type": "xsd:date"
       }
     },
     {
@@ -51002,6 +57309,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -51033,6 +57344,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -51064,6 +57379,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1001-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -51095,6 +57414,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2010-10-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -51126,6 +57449,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1997-09-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -51162,7 +57489,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2001-05-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31999L0079",
@@ -51193,6 +57524,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -51224,6 +57559,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2009-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -51255,6 +57594,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2010-08-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -51286,6 +57634,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2009-06-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -51317,6 +57669,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1980-02-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -51384,6 +57740,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2014-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -51415,6 +57775,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-11-16",
+        "@type": "xsd:date"
       }
     },
     {
@@ -51446,6 +57810,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-10-14",
+        "@type": "xsd:date"
       }
     },
     {
@@ -51554,7 +57922,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2012-11-10",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31991L0339",
@@ -51585,6 +57957,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-06-18",
+        "@type": "xsd:date"
       }
     },
     {
@@ -51616,6 +57992,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1991-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -51647,6 +58027,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2005-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -51678,6 +58062,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1977-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -51709,6 +58097,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-04-09",
+        "@type": "xsd:date"
       }
     },
     {
@@ -51745,7 +58137,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2007-12-15",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32001L0038",
@@ -51812,6 +58208,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -52025,7 +58425,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2016-04-19",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32004L0101",
@@ -52061,7 +58465,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2005-11-13",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32008L0115",
@@ -52097,7 +58505,16 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:VSS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2010-12-24",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31975L0439",
@@ -52128,6 +58545,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1977-06-18",
+        "@type": "xsd:date"
       }
     },
     {
@@ -52159,6 +58580,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2005-10-03",
+        "@type": "xsd:date"
       }
     },
     {
@@ -52195,7 +58620,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1988-07-03",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32010L0019",
@@ -52226,6 +58655,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-04-08",
+        "@type": "xsd:date"
       }
     },
     {
@@ -52257,6 +58690,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-12-15",
+        "@type": "xsd:date"
       }
     },
     {
@@ -52288,6 +58725,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -52319,6 +58760,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1975-01-27",
+        "@type": "xsd:date"
       }
     },
     {
@@ -52355,7 +58800,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2006-04-29",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32014L0052",
@@ -52391,7 +58840,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2017-05-16",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32001L0042",
@@ -52427,6 +58880,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:KeHJS_Map_2026"
+        }
       ]
     },
     {
@@ -52458,6 +58916,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:Sadamaseadus_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1996-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -52489,6 +58956,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1981-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -52520,6 +58991,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1982-10-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -52556,7 +59031,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2005-01-29",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31981L0334",
@@ -52587,6 +59066,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1981-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -52623,7 +59106,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2005-05-13",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32013L0051",
@@ -52654,6 +59141,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:RTerS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2015-11-28",
+        "@type": "xsd:date"
       }
     },
     {
@@ -52685,6 +59181,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1982-01-24",
+        "@type": "xsd:date"
       }
     },
     {
@@ -52716,6 +59216,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2014-07-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -52783,7 +59287,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2010-12-31",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31983L0090",
@@ -52814,6 +59322,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1985-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -52845,6 +59357,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -52912,6 +59428,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1989-04-06",
+        "@type": "xsd:date"
       }
     },
     {
@@ -52948,7 +59468,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2016-12-06",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32005L0068",
@@ -52984,7 +59508,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2007-12-10",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31981L0957",
@@ -53015,6 +59543,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1982-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -53051,7 +59583,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1995-12-31",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32004L0113",
@@ -53082,6 +59618,18 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:VõrdKS_Map_2026"
+        },
+        {
+          "@id": "estleg:SoVS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2007-12-21",
+        "@type": "xsd:date"
       }
     },
     {
@@ -53113,6 +59661,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-12-26",
+        "@type": "xsd:date"
       }
     },
     {
@@ -53149,7 +59701,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2017-09-10",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32008L0112",
@@ -53185,7 +59741,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2010-04-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32006L0043",
@@ -53221,7 +59781,16 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:AUDIIT_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2008-06-29",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31965L0469",
@@ -53252,6 +59821,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1966-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -53288,7 +59861,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2007-04-30",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31997L0039",
@@ -53319,6 +59896,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1997-10-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -53355,7 +59936,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2015-07-20",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31990L0335",
@@ -53386,6 +59971,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1991-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -53417,6 +60006,27 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "https://data.riik.ee/ontology/estleg#"
+        },
+        {
+          "@id": "estleg:VOS_Osa1_1_207"
+        },
+        {
+          "@id": "estleg:VOS_Osa3_Contract_Obligations_Liability"
+        },
+        {
+          "@id": "estleg:VOS_Osa4_Taitmine_Tasaarvestus_Vabastamine"
+        },
+        {
+          "@id": "estleg:VOS_Osa7_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1992-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -53453,7 +60063,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2015-03-31",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32007L0023",
@@ -53489,7 +60103,16 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:LOHKEM_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2010-01-04",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32008L0114",
@@ -53520,6 +60143,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:HADAOL_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2011-01-12",
+        "@type": "xsd:date"
       }
     },
     {
@@ -53556,7 +60188,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2005-09-22",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32006L0054",
@@ -53592,7 +60228,19 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:VõrdKS_Map_2026"
+        },
+        {
+          "@id": "estleg:SoVS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2008-08-15",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31987L0143",
@@ -53623,6 +60271,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1988-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -53659,7 +60311,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2015-03-31",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32015L2193",
@@ -53695,7 +60351,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2017-12-19",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32014L0069",
@@ -53726,6 +60386,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2014-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -53757,6 +60421,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1998-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -53788,6 +60456,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1989-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -53850,6 +60522,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-07-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -53912,6 +60588,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1987-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -53943,6 +60623,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1984-06-17",
+        "@type": "xsd:date"
       }
     },
     {
@@ -53974,6 +60658,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1989-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -54005,6 +60693,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-05-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -54036,6 +60728,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2014-01-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -54067,6 +60768,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1997-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -54103,7 +60808,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2016-04-18",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32013L0038",
@@ -54139,7 +60848,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2014-11-21",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32006L0127",
@@ -54170,6 +60883,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -54242,7 +60959,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2013-12-21",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31999L0094",
@@ -54278,7 +60999,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2001-01-18",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31989L0458",
@@ -54309,6 +61034,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1989-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -54340,6 +61069,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1996-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -54371,6 +61104,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1997-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -54402,6 +61139,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2009-10-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -54433,6 +61174,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1986-03-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -54500,6 +61245,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-10-12",
+        "@type": "xsd:date"
       }
     },
     {
@@ -54536,7 +61285,16 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:MSOS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2011-06-17",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31998L0070",
@@ -54572,7 +61330,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1999-07-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32008L0048R03",
@@ -54640,7 +61402,25 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:MSOS_Map_2026"
+        },
+        {
+          "@id": "estleg:ISIKUA_Map_2026"
+        },
+        {
+          "@id": "estleg:RAUDTEE_Map_2026"
+        },
+        {
+          "@id": "estleg:LENN_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2011-06-17",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31989L0677",
@@ -54671,6 +61451,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1991-06-20",
+        "@type": "xsd:date"
       }
     },
     {
@@ -54707,7 +61491,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2013-10-03",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31980L1269",
@@ -54738,6 +61526,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1982-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -54805,6 +61597,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1991-10-23",
+        "@type": "xsd:date"
       }
     },
     {
@@ -54836,6 +61632,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1979-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -54872,7 +61672,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2016-04-19",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32002L0015",
@@ -54908,6 +61712,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:LIIKLU_2_Map_2026"
+        }
       ]
     },
     {
@@ -54939,6 +61748,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2008-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -54970,6 +61783,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1997-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -55001,6 +61818,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1988-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -55037,7 +61858,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2016-11-29",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31974L0132",
@@ -55068,6 +61893,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1974-05-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -55099,6 +61928,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-10-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -55130,6 +61963,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-01-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -55161,6 +61998,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1987-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -55192,6 +62033,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1984-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -55223,6 +62068,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2010-11-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -55259,7 +62108,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2015-07-09",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31993L0083",
@@ -55290,6 +62143,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1995-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -55321,6 +62178,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -55352,6 +62213,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -55383,6 +62248,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2010-12-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -55414,6 +62283,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1981-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -55445,6 +62318,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-01-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -55476,6 +62353,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-02-28",
+        "@type": "xsd:date"
       }
     },
     {
@@ -55507,6 +62388,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -55538,6 +62423,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-10-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -55569,6 +62458,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -55600,6 +62493,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-07-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -55631,6 +62528,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-03-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -55662,6 +62563,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-11-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -55693,6 +62598,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -55724,6 +62633,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -55755,6 +62668,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1990-02-16",
+        "@type": "xsd:date"
       }
     },
     {
@@ -55817,6 +62734,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-10-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -55848,6 +62769,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-03-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -55879,6 +62804,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -55910,6 +62839,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2010-12-24",
+        "@type": "xsd:date"
       }
     },
     {
@@ -55941,6 +62874,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-11-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -55972,6 +62909,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -56008,7 +62949,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2005-10-30",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31998L0086",
@@ -56039,6 +62984,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -56070,6 +63019,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1995-05-02",
+        "@type": "xsd:date"
       }
     },
     {
@@ -56101,6 +63054,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2010-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -56132,6 +63089,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-09-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -56163,6 +63124,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-09-14",
+        "@type": "xsd:date"
       }
     },
     {
@@ -56194,6 +63159,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-10-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -56225,6 +63194,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-10-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -56256,6 +63229,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-11-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -56292,7 +63269,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2002-04-27",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31994L0057",
@@ -56323,6 +63304,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1995-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -56390,6 +63375,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-04-10",
+        "@type": "xsd:date"
       }
     },
     {
@@ -56421,6 +63410,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2010-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -56452,6 +63445,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1986-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -56483,6 +63480,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-10-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -56519,7 +63520,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2016-06-12",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31971L0317",
@@ -56550,6 +63555,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1973-01-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -56581,6 +63590,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1987-11-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -56617,7 +63630,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2015-11-14",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32011L0076",
@@ -56653,7 +63670,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2013-10-16",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31974L0148",
@@ -56684,6 +63705,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1975-09-07",
+        "@type": "xsd:date"
       }
     },
     {
@@ -56715,6 +63740,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1981-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -56746,6 +63775,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -56782,7 +63815,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2004-01-15",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32009L0132",
@@ -56844,6 +63881,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -56916,7 +63957,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2013-01-02",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31993L0056",
@@ -56947,6 +63992,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -56978,6 +64027,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-04-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -57009,6 +64062,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1984-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -57045,7 +64102,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1995-07-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31992L0033",
@@ -57076,6 +64137,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -57107,6 +64172,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1995-11-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -57138,6 +64207,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1976-06-19",
+        "@type": "xsd:date"
       }
     },
     {
@@ -57205,7 +64278,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2015-06-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31976L0766",
@@ -57236,6 +64313,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1978-08-02",
+        "@type": "xsd:date"
       }
     },
     {
@@ -57267,6 +64348,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1974-02-10",
+        "@type": "xsd:date"
       }
     },
     {
@@ -57298,6 +64383,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1001-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -57329,6 +64418,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1991-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -57360,6 +64453,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2015-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -57391,6 +64488,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1973-04-15",
+        "@type": "xsd:date"
       }
     },
     {
@@ -57427,7 +64528,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2011-06-30",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32008L0084",
@@ -57458,6 +64563,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1997-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -57489,6 +64598,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1973-04-15",
+        "@type": "xsd:date"
       }
     },
     {
@@ -57520,6 +64633,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1982-01-10",
+        "@type": "xsd:date"
       }
     },
     {
@@ -57654,6 +64771,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1990-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -57685,6 +64806,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2010-11-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -57716,6 +64841,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:RAUDTEE_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2008-07-27",
+        "@type": "xsd:date"
       }
     },
     {
@@ -57809,6 +64943,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -57871,6 +65009,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-05-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -57902,6 +65044,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1987-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -57933,6 +65079,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1962-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -57964,6 +65114,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -57995,6 +65149,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-07-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -58031,7 +65189,28 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "https://data.riik.ee/ontology/estleg#"
+        },
+        {
+          "@id": "estleg:VOS_Osa1_1_207"
+        },
+        {
+          "@id": "estleg:VOS_Osa3_Contract_Obligations_Liability"
+        },
+        {
+          "@id": "estleg:VOS_Osa4_Taitmine_Tasaarvestus_Vabastamine"
+        },
+        {
+          "@id": "estleg:VOS_Osa7_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2000-06-04",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32011L0018",
@@ -58062,6 +65241,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -58093,6 +65276,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1980-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -58124,6 +65311,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -58160,7 +65351,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1995-04-30",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31989L0686",
@@ -58191,6 +65386,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1991-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -58222,6 +65421,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1997-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -58253,6 +65456,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1991-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -58284,6 +65491,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-06-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -58351,6 +65562,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1990-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -58387,7 +65602,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1975-09-08",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31994L0071",
@@ -58418,6 +65637,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1995-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -58449,6 +65672,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2010-04-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -58547,6 +65774,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1998-04-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -58583,7 +65814,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1994-12-14",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32009L0067",
@@ -58650,6 +65885,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1991-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -58681,6 +65920,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1996-02-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -58712,6 +65955,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2008-05-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -58748,7 +65995,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1978-10-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32009L0068",
@@ -58784,7 +66035,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1980-11-21",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32002L0034",
@@ -58851,7 +66106,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1980-11-21",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32009L0059",
@@ -58887,7 +66146,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1976-01-02",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32010L0075",
@@ -58923,7 +66186,16 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:THS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2013-01-07",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32008L0040",
@@ -58954,6 +66226,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2009-04-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -58990,7 +66266,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1994-12-14",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31994L0078",
@@ -59021,6 +66301,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1995-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -59052,6 +66336,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-01-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -59083,6 +66371,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2008-07-09",
+        "@type": "xsd:date"
       }
     },
     {
@@ -59114,6 +66406,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1976-10-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -59150,7 +66446,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1975-09-08",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32000L0075",
@@ -59181,6 +66481,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2002-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -59212,6 +66516,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1997-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -59274,6 +66582,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2003-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -59305,6 +66617,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-10-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -59336,6 +66652,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-10-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -59367,6 +66687,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1973-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -59398,6 +66722,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1990-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -59429,6 +66757,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1978-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -59460,6 +66792,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:KMS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2010-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -59491,6 +66832,21 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:KIIRGU_Map_2026"
+        },
+        {
+          "@id": "estleg:RIIGI_Map_2026"
+        },
+        {
+          "@id": "estleg:AVTS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2014-07-22",
+        "@type": "xsd:date"
       }
     },
     {
@@ -59522,6 +66878,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-03-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -59553,6 +66913,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1977-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -59584,6 +66948,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2012-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -59615,6 +66988,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:KMS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2010-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -59646,6 +67028,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-05-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -59677,6 +67063,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1978-02-03",
+        "@type": "xsd:date"
       }
     },
     {
@@ -59713,7 +67103,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2010-07-13",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32005L0085",
@@ -59744,6 +67138,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-12-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -59775,6 +67173,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2009-06-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -59806,6 +67208,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1998-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -59837,6 +67243,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1970-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -59868,6 +67278,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-02-16",
+        "@type": "xsd:date"
       }
     },
     {
@@ -59904,7 +67318,16 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:TNV_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2008-12-31",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32010L0045",
@@ -59935,6 +67358,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2012-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -59966,6 +67393,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2005-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -60001,6 +67432,17 @@
         },
         {
           "@id": "estleg:EUInst_EuropeanParliament"
+        }
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:VõrdKS_Map_2026"
+        },
+        {
+          "@id": "estleg:SoVS_Map_2026"
+        },
+        {
+          "@id": "estleg:TLS_Map_2026"
         }
       ]
     },
@@ -60038,7 +67480,16 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:TarbKS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2011-03-03",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31978L0692",
@@ -60069,6 +67520,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1977-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -60131,6 +67586,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1991-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -60162,6 +67621,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2010-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -60193,6 +67656,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-10-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -60229,7 +67696,16 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:Sadamaseadus_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2007-06-15",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32001L0044",
@@ -60291,6 +67767,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2005-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -60322,6 +67802,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1975-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -60353,6 +67837,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-10-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -60384,6 +67872,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1984-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -60420,7 +67912,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2008-06-29",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31993L0021",
@@ -60451,6 +67947,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -60482,6 +67982,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2009-07-08",
+        "@type": "xsd:date"
       }
     },
     {
@@ -60518,7 +68022,19 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:Sadamaseadus_Map_2026"
+        },
+        {
+          "@id": "estleg:MSOS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2010-12-31",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32007L0032",
@@ -60549,6 +68065,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-12-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -60580,6 +68100,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1991-12-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -60611,6 +68135,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1995-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -60642,6 +68170,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1002-02-02",
+        "@type": "xsd:date"
       }
     },
     {
@@ -60673,6 +68205,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-12-15",
+        "@type": "xsd:date"
       }
     },
     {
@@ -60709,7 +68245,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1998-06-30",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32009L0033",
@@ -60745,7 +68285,16 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:RIIGIH_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2010-12-04",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32009L0017",
@@ -60781,7 +68330,16 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:MSOS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2010-11-30",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32001L0065",
@@ -60848,6 +68406,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2015-07-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -60879,6 +68441,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1990-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -60915,7 +68481,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1999-02-18",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32001L0055",
@@ -60977,6 +68547,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -61013,7 +68587,58 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "https://data.riik.ee/ontology/estleg#"
+        },
+        {
+          "@id": "estleg:VOS_Osa1_1_207"
+        },
+        {
+          "@id": "estleg:VOS_Osa3_Contract_Obligations_Liability"
+        },
+        {
+          "@id": "estleg:VOS_Osa4_Taitmine_Tasaarvestus_Vabastamine"
+        },
+        {
+          "@id": "estleg:VOS_Osa7_Map_2026"
+        },
+        {
+          "@id": "estleg:RVastS_Map_2026"
+        },
+        {
+          "@id": "estleg:TLS_Map_2026"
+        },
+        {
+          "@id": "estleg:KARIST_2_Osa1_1_87"
+        },
+        {
+          "@id": "estleg:KARIST_2_Osa2_88_451"
+        },
+        {
+          "@id": "estleg:ITVS_Map_2026"
+        },
+        {
+          "@id": "estleg:HMS_Map_2026"
+        },
+        {
+          "@id": "estleg:VALISM_Map_2026"
+        },
+        {
+          "@id": "estleg:TsÜS_Osa2_7_47"
+        },
+        {
+          "@id": "estleg:TsÜS_Osa4_67_131"
+        },
+        {
+          "@id": "estleg:TsÜS_Osa7_138_169"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2011-07-20",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31997L0011",
@@ -61044,6 +68669,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-03-14",
+        "@type": "xsd:date"
       }
     },
     {
@@ -61075,6 +68704,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2009-04-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -61106,6 +68739,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2016-05-20",
+        "@type": "xsd:date"
       }
     },
     {
@@ -61200,6 +68837,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -61231,6 +68872,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2010-09-15",
+        "@type": "xsd:date"
       }
     },
     {
@@ -61262,6 +68907,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2005-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -61324,6 +68973,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2010-04-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -61355,6 +69008,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2012-07-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -61386,6 +69043,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-12-14",
+        "@type": "xsd:date"
       }
     },
     {
@@ -61417,6 +69078,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1995-06-14",
+        "@type": "xsd:date"
       }
     },
     {
@@ -61453,7 +69118,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2016-04-19",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31985L0433",
@@ -61484,6 +69153,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1987-10-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -61515,6 +69188,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1971-06-16",
+        "@type": "xsd:date"
       }
     },
     {
@@ -61551,7 +69228,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2007-08-10",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32009L0069",
@@ -61582,6 +69263,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:KMS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2011-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -61618,7 +69308,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2006-01-31",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31980L0779",
@@ -61649,6 +69343,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1982-07-18",
+        "@type": "xsd:date"
       }
     },
     {
@@ -61680,6 +69378,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1985-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -61711,6 +69413,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -61742,6 +69448,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1979-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -61778,7 +69488,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2008-09-05",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32003L0091",
@@ -61809,6 +69523,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-03-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -61840,6 +69558,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2013-03-20",
+        "@type": "xsd:date"
       }
     },
     {
@@ -61871,6 +69593,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-03-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -61938,6 +69664,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1981-12-19",
+        "@type": "xsd:date"
       }
     },
     {
@@ -61969,6 +69699,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2000-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -62000,6 +69734,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2005-08-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -62036,7 +69774,16 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:RPKS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2012-08-05",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31987L0328",
@@ -62067,6 +69814,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1989-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -62103,7 +69854,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2008-12-30",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32011L0030",
@@ -62134,6 +69889,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-11-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -62165,6 +69924,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2005-12-14",
+        "@type": "xsd:date"
       }
     },
     {
@@ -62196,6 +69959,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -62227,6 +69994,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-09-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -62263,7 +70034,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2013-10-25",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32015L1139",
@@ -62325,6 +70100,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -62356,6 +70135,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1995-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -62387,6 +70170,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-07-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -62477,6 +70264,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -62508,6 +70299,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:KMS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2011-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -62539,6 +70339,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2010-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -62575,7 +70384,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2013-10-27",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32014L0024",
@@ -62611,7 +70424,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2016-04-18",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31988L0667",
@@ -62642,6 +70459,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1989-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -62678,7 +70499,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2013-01-02",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32008L0019",
@@ -62745,6 +70570,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -62817,7 +70646,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2012-12-31",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32008L0082",
@@ -62848,6 +70681,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2009-02-20",
+        "@type": "xsd:date"
       }
     },
     {
@@ -62879,6 +70716,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1983-02-20",
+        "@type": "xsd:date"
       }
     },
     {
@@ -62910,6 +70751,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1980-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -62941,6 +70786,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1972-07-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -62972,6 +70821,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1984-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -63003,6 +70856,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2016-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -63039,7 +70896,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2014-10-29",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31979L0802",
@@ -63070,6 +70931,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1980-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -63132,6 +70997,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1980-06-09",
+        "@type": "xsd:date"
       }
     },
     {
@@ -63163,6 +71032,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1980-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -63230,6 +71103,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1996-01-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -63261,6 +71138,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1976-05-05",
+        "@type": "xsd:date"
       }
     },
     {
@@ -63297,6 +71178,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:MEEDIA_Map_2026"
+        }
       ]
     },
     {
@@ -63328,6 +71214,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1995-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -63359,6 +71249,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1977-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -63426,6 +71320,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1995-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -63488,6 +71386,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1991-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -63550,6 +71452,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2010-11-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -63581,6 +71487,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2015-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -63612,6 +71522,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1977-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -63643,6 +71557,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2013-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -63674,6 +71592,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -63710,7 +71632,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2006-12-31",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32013L0022",
@@ -63741,6 +71667,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2013-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -63772,6 +71702,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2014-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -63803,6 +71737,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1989-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -63834,6 +71772,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:MSOS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2012-03-16",
+        "@type": "xsd:date"
       }
     },
     {
@@ -63927,6 +71874,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2013-03-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -63989,6 +71945,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -64020,6 +71980,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1988-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -64051,6 +72015,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2013-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -64082,6 +72055,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -64113,6 +72090,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-03-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -64144,6 +72125,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2013-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -64175,6 +72160,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1996-03-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -64206,6 +72195,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1998-03-16",
+        "@type": "xsd:date"
       }
     },
     {
@@ -64237,6 +72230,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-03-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -64268,6 +72265,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -64299,6 +72300,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2018-02-06",
+        "@type": "xsd:date"
       }
     },
     {
@@ -64330,6 +72335,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2013-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -64361,6 +72370,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-03-11",
+        "@type": "xsd:date"
       }
     },
     {
@@ -64423,6 +72436,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2013-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -64454,6 +72476,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1991-01-02",
+        "@type": "xsd:date"
       }
     },
     {
@@ -64485,6 +72511,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2005-05-14",
+        "@type": "xsd:date"
       }
     },
     {
@@ -64516,6 +72546,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2013-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -64547,6 +72586,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1990-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -64583,7 +72626,22 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:VEE_Map_2026"
+        },
+        {
+          "@id": "estleg:KARIST_2_Osa1_1_87"
+        },
+        {
+          "@id": "estleg:KARIST_2_Osa2_88_451"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2010-11-16",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32012L0040",
@@ -64614,6 +72672,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2013-03-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -64645,6 +72712,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1997-06-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -64676,6 +72747,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-12-25",
+        "@type": "xsd:date"
       }
     },
     {
@@ -64712,7 +72787,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2007-03-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31995L0049",
@@ -64743,6 +72822,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1995-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -64774,6 +72857,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1997-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -64810,7 +72897,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2012-05-19",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31989L0617",
@@ -64841,6 +72932,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1991-11-29",
+        "@type": "xsd:date"
       }
     },
     {
@@ -64872,6 +72967,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1982-07-18",
+        "@type": "xsd:date"
       }
     },
     {
@@ -64903,6 +73002,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1996-11-23",
+        "@type": "xsd:date"
       }
     },
     {
@@ -64934,6 +73037,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1995-04-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -64965,6 +73072,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-01-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -64996,6 +73107,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1978-05-09",
+        "@type": "xsd:date"
       }
     },
     {
@@ -65032,7 +73147,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2013-11-07",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32008L0051",
@@ -65068,7 +73187,16 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:RelvS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2010-07-28",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31999L0105",
@@ -65099,6 +73227,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2003-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -65166,6 +73298,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1988-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -65202,7 +73338,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1986-10-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31983L0513",
@@ -65233,6 +73373,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1985-09-28",
+        "@type": "xsd:date"
       }
     },
     {
@@ -65295,6 +73439,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1973-01-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -65326,6 +73474,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1976-11-21",
+        "@type": "xsd:date"
       }
     },
     {
@@ -65357,6 +73509,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1987-10-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -65388,6 +73544,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1975-05-22",
+        "@type": "xsd:date"
       }
     },
     {
@@ -65424,7 +73584,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2015-07-03",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31977L0540",
@@ -65455,6 +73619,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1978-06-29",
+        "@type": "xsd:date"
       }
     },
     {
@@ -65486,6 +73654,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-03-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -65517,6 +73689,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -65548,6 +73724,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1978-06-22",
+        "@type": "xsd:date"
       }
     },
     {
@@ -65584,7 +73764,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2007-01-20",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31976L0160",
@@ -65615,6 +73799,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1977-12-10",
+        "@type": "xsd:date"
       }
     },
     {
@@ -65651,7 +73839,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2016-04-19",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32004L0050",
@@ -65687,7 +73879,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2006-04-30",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32000L0009",
@@ -65723,7 +73919,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2002-05-03",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32015L0413",
@@ -65759,7 +73959,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2015-05-06",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32007L0049",
@@ -65790,6 +73994,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-10-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -65826,7 +74034,16 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:TNV_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2011-01-20",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31990L0396",
@@ -65857,6 +74074,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1991-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -65888,6 +74109,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -65919,6 +74144,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2015-11-18",
+        "@type": "xsd:date"
       }
     },
     {
@@ -65981,6 +74210,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2010-09-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -66017,7 +74250,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2012-02-27",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31987L0372",
@@ -66048,6 +74285,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1988-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -66110,6 +74351,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2005-05-10",
+        "@type": "xsd:date"
       }
     },
     {
@@ -66146,7 +74391,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2003-07-24",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32009L0023",
@@ -66182,7 +74431,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1992-06-30",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32008L0070",
@@ -66213,6 +74466,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2009-05-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -66275,6 +74532,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1980-07-19",
+        "@type": "xsd:date"
       }
     },
     {
@@ -66311,7 +74572,25 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:VPTS_Map_2026"
+        },
+        {
+          "@id": "estleg:FIS_Map_2026"
+        },
+        {
+          "@id": "estleg:INVEST_Map_2026"
+        },
+        {
+          "@id": "estleg:KREDII_2_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2010-10-31",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32004L0062",
@@ -66342,6 +74621,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2005-03-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -66373,6 +74656,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2010-02-20",
+        "@type": "xsd:date"
       }
     },
     {
@@ -66404,6 +74696,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2010-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -66435,6 +74731,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1985-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -66466,6 +74766,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-10-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -66497,6 +74801,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2009-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -66528,6 +74836,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2009-10-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -66564,7 +74876,16 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:TNV_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2010-11-20",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31993L0076",
@@ -66595,6 +74916,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -66626,6 +74951,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1986-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -66657,6 +74986,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2009-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -66693,7 +75026,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2000-05-23",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32004L0019",
@@ -66724,6 +75061,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2005-09-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -66755,6 +75096,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-10-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -66786,6 +75131,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1996-09-22",
+        "@type": "xsd:date"
       }
     },
     {
@@ -66817,6 +75166,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1964-09-19",
+        "@type": "xsd:date"
       }
     },
     {
@@ -66848,6 +75201,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2000-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -66884,7 +75241,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2016-06-18",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31986L0174",
@@ -66915,6 +75276,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1987-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -66977,6 +75342,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2011-10-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -67008,6 +75382,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1997-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -67039,6 +75417,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1980-11-21",
+        "@type": "xsd:date"
       }
     },
     {
@@ -67070,6 +75452,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1971-10-07",
+        "@type": "xsd:date"
       }
     },
     {
@@ -67101,6 +75487,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1981-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -67137,7 +75527,16 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:TaimKS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2011-12-14",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31998L0084",
@@ -67173,7 +75572,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2000-05-28",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32014L0042",
@@ -67209,7 +75612,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2015-10-04",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32014L0089",
@@ -67245,7 +75652,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2016-09-18",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31968L0360",
@@ -67276,6 +75687,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1969-07-16",
+        "@type": "xsd:date"
       }
     },
     {
@@ -67307,6 +75722,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2013-01-20",
+        "@type": "xsd:date"
       }
     },
     {
@@ -67338,6 +75757,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2013-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -67369,6 +75792,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2013-05-11",
+        "@type": "xsd:date"
       }
     },
     {
@@ -67400,6 +75827,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -67431,6 +75862,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -67462,6 +75897,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1997-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -67493,6 +75932,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1987-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -67524,6 +75967,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -67555,6 +76002,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2014-05-12",
+        "@type": "xsd:date"
       }
     },
     {
@@ -67586,6 +76037,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1987-12-23",
+        "@type": "xsd:date"
       }
     },
     {
@@ -67653,7 +76108,16 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:MASINA_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2011-06-15",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32015L0566",
@@ -67684,6 +76148,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2016-10-29",
+        "@type": "xsd:date"
       }
     },
     {
@@ -67715,6 +76183,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1979-10-12",
+        "@type": "xsd:date"
       }
     },
     {
@@ -67746,6 +76218,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-10-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -67777,6 +76253,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1984-06-21",
+        "@type": "xsd:date"
       }
     },
     {
@@ -67808,6 +76288,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1987-08-05",
+        "@type": "xsd:date"
       }
     },
     {
@@ -67839,6 +76323,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1997-06-27",
+        "@type": "xsd:date"
       }
     },
     {
@@ -67875,7 +76363,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1995-09-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32006L0028",
@@ -67906,6 +76398,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -67937,6 +76433,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1977-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -67968,6 +76468,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-02-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -68004,7 +76508,16 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:RIIGIH_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2011-08-21",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31985L0413",
@@ -68035,6 +76548,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1986-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -68066,6 +76583,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1990-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -68151,6 +76672,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2010-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -68187,7 +76712,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1999-02-14",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32008L0089",
@@ -68218,6 +76747,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2009-10-15",
+        "@type": "xsd:date"
       }
     },
     {
@@ -68249,6 +76782,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1989-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -68280,6 +76817,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -68311,6 +76852,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -68342,6 +76887,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2005-02-08",
+        "@type": "xsd:date"
       }
     },
     {
@@ -68373,6 +76922,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1991-05-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -68404,6 +76957,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1990-06-20",
+        "@type": "xsd:date"
       }
     },
     {
@@ -68466,6 +77023,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-06-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -68497,6 +77058,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-10-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -68533,7 +77098,25 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:RTRT_Map_2026"
+        },
+        {
+          "@id": "estleg:KREDII_2_Map_2026"
+        },
+        {
+          "@id": "estleg:MERA_Map_2026"
+        },
+        {
+          "@id": "estleg:FIS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2011-04-30",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31994L0038",
@@ -68564,6 +77147,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-10-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -68595,6 +77182,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1986-04-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -68657,6 +77248,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -68693,7 +77288,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2006-01-31",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31977L0391",
@@ -68724,6 +77323,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1977-07-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -68755,6 +77358,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1998-03-09",
+        "@type": "xsd:date"
       }
     },
     {
@@ -68786,6 +77393,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1988-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -68822,7 +77433,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1992-12-31",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31999L0076",
@@ -68853,6 +77468,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-10-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -68889,7 +77508,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2006-04-07",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32009L0161",
@@ -68920,6 +77543,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-12-18",
+        "@type": "xsd:date"
       }
     },
     {
@@ -68987,7 +77614,19 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:ESS_Map_2026"
+        },
+        {
+          "@id": "estleg:InfoTS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2011-05-25",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31996L0071",
@@ -69023,7 +77662,16 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:ELTTS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1999-12-16",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31996L0035",
@@ -69054,6 +77702,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -69085,6 +77737,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2009-03-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -69116,6 +77777,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1982-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -69152,7 +77817,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1976-05-05",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32013L0027",
@@ -69183,6 +77852,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2014-04-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -69219,7 +77892,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2015-07-18",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31995L0029",
@@ -69250,6 +77927,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1996-12-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -69281,6 +77962,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1998-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -69312,6 +77997,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2005-11-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -69343,6 +78032,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -69410,6 +78103,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2012-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -69446,7 +78148,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2012-08-27",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31975L0443",
@@ -69477,6 +78183,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1976-04-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -69508,6 +78218,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-08-21",
+        "@type": "xsd:date"
       }
     },
     {
@@ -69539,6 +78253,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1002-02-02",
+        "@type": "xsd:date"
       }
     },
     {
@@ -69570,6 +78288,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1989-06-26",
+        "@type": "xsd:date"
       }
     },
     {
@@ -69606,7 +78328,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2006-04-30",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31979L1070",
@@ -69637,6 +78363,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1981-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -69668,6 +78398,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2005-10-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -69699,6 +78433,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1989-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -69730,6 +78468,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-11-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -69761,6 +78503,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -69792,6 +78538,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2014-04-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -69828,7 +78578,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1998-09-22",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32012L0002",
@@ -69859,6 +78613,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2013-01-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -69921,6 +78684,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2013-10-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -69952,6 +78719,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -69983,6 +78754,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-10-12",
+        "@type": "xsd:date"
       }
     },
     {
@@ -70019,7 +78794,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2015-12-18",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31986L0297",
@@ -70050,6 +78829,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1987-12-02",
+        "@type": "xsd:date"
       }
     },
     {
@@ -70081,6 +78864,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1967-06-26",
+        "@type": "xsd:date"
       }
     },
     {
@@ -70112,6 +78899,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2012-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -70143,6 +78939,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1978-06-17",
+        "@type": "xsd:date"
       }
     },
     {
@@ -70174,6 +78974,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2014-06-17",
+        "@type": "xsd:date"
       }
     },
     {
@@ -70241,6 +79045,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -70272,6 +79080,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1987-12-23",
+        "@type": "xsd:date"
       }
     },
     {
@@ -70308,7 +79120,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2015-06-16",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31982L0884",
@@ -70339,6 +79155,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1984-12-10",
+        "@type": "xsd:date"
       }
     },
     {
@@ -70437,6 +79257,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1989-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -70473,7 +79297,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1995-12-16",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32008L0106",
@@ -70540,6 +79368,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1973-04-15",
+        "@type": "xsd:date"
       }
     },
     {
@@ -70576,7 +79408,19 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:MEDITS_Map_2026"
+        },
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2007-12-21",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32007L0057",
@@ -70607,6 +79451,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2008-03-18",
+        "@type": "xsd:date"
       }
     },
     {
@@ -70638,6 +79486,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1973-01-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -70669,6 +79521,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1985-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -70700,6 +79556,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1976-12-27",
+        "@type": "xsd:date"
       }
     },
     {
@@ -70731,6 +79591,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -70767,7 +79631,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2004-10-12",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32015L0720",
@@ -70803,7 +79671,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2016-11-27",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31994L0065",
@@ -70834,6 +79706,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1996-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -70865,6 +79741,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1985-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -70896,6 +79776,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1978-12-29",
+        "@type": "xsd:date"
       }
     },
     {
@@ -70932,7 +79816,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2000-01-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31987L0404",
@@ -70963,6 +79851,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1989-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -70999,7 +79891,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1997-01-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32007L0045",
@@ -71035,7 +79931,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2008-10-11",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31978L0687",
@@ -71066,6 +79966,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1980-01-28",
+        "@type": "xsd:date"
       }
     },
     {
@@ -71133,6 +80037,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1998-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -71200,6 +80108,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1998-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -71231,6 +80143,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1986-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -71262,6 +80178,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-04-08",
+        "@type": "xsd:date"
       }
     },
     {
@@ -71298,7 +80218,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1974-08-21",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32008L0029",
@@ -71365,6 +80289,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2000-10-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -71396,6 +80324,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2016-05-20",
+        "@type": "xsd:date"
       }
     },
     {
@@ -71463,6 +80395,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1983-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -71494,6 +80430,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1991-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -71530,7 +80470,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2000-07-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31995L0050",
@@ -71561,6 +80505,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1997-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -71592,6 +80540,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1997-04-15",
+        "@type": "xsd:date"
       }
     },
     {
@@ -71623,6 +80575,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1976-11-21",
+        "@type": "xsd:date"
       }
     },
     {
@@ -71654,6 +80610,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2014-07-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -71685,6 +80645,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2014-08-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -71716,6 +80685,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -71778,6 +80751,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1975-12-18",
+        "@type": "xsd:date"
       }
     },
     {
@@ -71809,6 +80786,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-07-28",
+        "@type": "xsd:date"
       }
     },
     {
@@ -71840,6 +80821,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2015-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -71871,6 +80856,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2013-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -71938,6 +80927,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2005-01-15",
+        "@type": "xsd:date"
       }
     },
     {
@@ -71969,6 +80962,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2011-04-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -72000,6 +81002,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-11-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -72031,6 +81037,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -72062,6 +81072,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-11-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -72093,6 +81107,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1986-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -72124,6 +81142,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2008-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -72160,7 +81182,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2000-09-20",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32002L0032",
@@ -72227,6 +81253,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2017-04-21",
+        "@type": "xsd:date"
       }
     },
     {
@@ -72258,6 +81288,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1990-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -72289,6 +81323,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2013-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -72320,6 +81358,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1989-10-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -72351,6 +81393,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1985-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -72382,6 +81428,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1978-11-23",
+        "@type": "xsd:date"
       }
     },
     {
@@ -72413,6 +81463,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -72444,6 +81498,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1984-10-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -72475,6 +81533,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1986-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -72511,7 +81573,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2013-12-18",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32005L0049",
@@ -72542,6 +81608,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -72573,6 +81643,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1001-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -72604,6 +81678,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1979-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -72640,7 +81718,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2011-09-24",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32009L0041",
@@ -72712,7 +81794,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2017-05-07",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32001L0037",
@@ -72779,6 +81865,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1990-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -72815,7 +81905,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2013-05-20",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31969L0335",
@@ -72846,6 +81940,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1972-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -72877,6 +81975,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1990-11-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -72908,6 +82010,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1988-10-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -72939,6 +82045,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-11-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -72970,6 +82080,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-05-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -73001,6 +82115,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -73032,6 +82150,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1996-12-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -73063,6 +82185,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -73094,6 +82220,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1981-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -73125,6 +82255,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1988-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -73156,6 +82290,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2005-06-29",
+        "@type": "xsd:date"
       }
     },
     {
@@ -73187,6 +82325,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1986-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -73218,6 +82360,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-11-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -73249,6 +82395,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -73280,6 +82430,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2008-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -73311,6 +82465,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1990-11-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -73378,7 +82536,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2000-09-13",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32003L0074",
@@ -73409,6 +82571,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-10-14",
+        "@type": "xsd:date"
       }
     },
     {
@@ -73481,7 +82647,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2004-06-30",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32004L0045",
@@ -73512,6 +82682,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2005-04-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -73543,6 +82717,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1987-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -73574,6 +82752,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2005-05-20",
+        "@type": "xsd:date"
       }
     },
     {
@@ -73605,6 +82787,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2005-04-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -73636,6 +82822,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1996-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -73667,6 +82857,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1977-07-22",
+        "@type": "xsd:date"
       }
     },
     {
@@ -73703,7 +82897,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2003-08-03",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32000L0034",
@@ -73739,7 +82937,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2003-08-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32002L0067",
@@ -73801,6 +83003,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2002-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -73832,6 +83038,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-08-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -73863,6 +83073,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1995-06-29",
+        "@type": "xsd:date"
       }
     },
     {
@@ -73894,6 +83108,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-05-22",
+        "@type": "xsd:date"
       }
     },
     {
@@ -73930,7 +83148,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2005-07-04",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31983L0191",
@@ -73961,6 +83183,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1984-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -73992,6 +83218,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-12-23",
+        "@type": "xsd:date"
       }
     },
     {
@@ -74023,6 +83253,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2008-08-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -74054,6 +83288,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2005-09-21",
+        "@type": "xsd:date"
       }
     },
     {
@@ -74085,6 +83323,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1996-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -74116,6 +83358,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1986-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -74147,6 +83393,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -74178,6 +83428,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-11-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -74209,6 +83463,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2005-02-28",
+        "@type": "xsd:date"
       }
     },
     {
@@ -74271,6 +83529,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1986-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -74338,6 +83600,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:KMS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2011-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -74369,6 +83640,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2003-02-28",
+        "@type": "xsd:date"
       }
     },
     {
@@ -74400,6 +83675,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2005-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -74431,6 +83710,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2008-05-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -74462,6 +83745,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2005-12-03",
+        "@type": "xsd:date"
       }
     },
     {
@@ -74493,6 +83780,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1996-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -74529,7 +83820,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2013-11-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32002L0014",
@@ -74596,6 +83891,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1989-06-18",
+        "@type": "xsd:date"
       }
     },
     {
@@ -74658,6 +83957,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-08-27",
+        "@type": "xsd:date"
       }
     },
     {
@@ -74689,6 +83992,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2016-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -74756,6 +84063,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1988-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -74787,6 +84098,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2010-09-15",
+        "@type": "xsd:date"
       }
     },
     {
@@ -74823,7 +84138,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2016-11-27",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32011L0059",
@@ -74854,6 +84173,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2012-01-03",
+        "@type": "xsd:date"
       }
     },
     {
@@ -74885,6 +84208,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2008-01-04",
+        "@type": "xsd:date"
       }
     },
     {
@@ -74916,6 +84243,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-09-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -74947,6 +84278,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1990-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -74983,7 +84318,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2008-05-31",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32007L0008",
@@ -75014,6 +84353,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-09-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -75045,6 +84388,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-09-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -75081,7 +84428,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2017-05-20",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32004L0076",
@@ -75112,6 +84463,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-05-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -75143,6 +84498,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1998-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -75174,6 +84533,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1996-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -75205,6 +84568,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2013-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -75236,6 +84603,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2000-12-13",
+        "@type": "xsd:date"
       }
     },
     {
@@ -75267,6 +84638,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1981-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -75303,7 +84678,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1992-12-31",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31994L0059",
@@ -75334,6 +84713,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1995-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -75365,6 +84748,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2014-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -75396,6 +84783,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1996-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -75427,6 +84818,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-11-21",
+        "@type": "xsd:date"
       }
     },
     {
@@ -75463,7 +84858,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2005-11-19",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32006L0008",
@@ -75494,6 +84893,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-03-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -75525,6 +84928,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2013-03-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -75561,7 +84968,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2012-07-21",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32013L0010",
@@ -75592,6 +85003,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2014-03-19",
+        "@type": "xsd:date"
       }
     },
     {
@@ -75687,6 +85102,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -75718,6 +85137,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -75749,6 +85172,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1998-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -75780,6 +85207,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2013-08-22",
+        "@type": "xsd:date"
       }
     },
     {
@@ -75811,6 +85242,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2012-06-02",
+        "@type": "xsd:date"
       }
     },
     {
@@ -75847,7 +85282,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2009-04-28",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32008L0059",
@@ -75878,6 +85317,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2008-12-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -75909,6 +85352,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2013-01-02",
+        "@type": "xsd:date"
       }
     },
     {
@@ -75940,6 +85387,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1998-12-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -75971,6 +85422,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2014-07-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -76002,6 +85457,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2013-01-02",
+        "@type": "xsd:date"
       }
     },
     {
@@ -76033,6 +85492,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2012-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -76064,6 +85527,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2009-01-02",
+        "@type": "xsd:date"
       }
     },
     {
@@ -76100,7 +85567,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2010-04-27",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32004L0041",
@@ -76136,7 +85607,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2006-01-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32010L0036",
@@ -76167,6 +85642,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:MSOS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2011-06-28",
+        "@type": "xsd:date"
       }
     },
     {
@@ -76198,6 +85682,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1997-01-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -76229,7 +85717,12 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
-      }
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:KMS_Map_2026"
+        }
+      ]
     },
     {
       "@id": "estleg:EU_32004L0030",
@@ -76260,6 +85753,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-11-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -76291,6 +85788,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1979-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -76322,6 +85823,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1983-01-24",
+        "@type": "xsd:date"
       }
     },
     {
@@ -76353,6 +85858,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2003-04-29",
+        "@type": "xsd:date"
       }
     },
     {
@@ -76384,6 +85893,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2000-06-27",
+        "@type": "xsd:date"
       }
     },
     {
@@ -76415,6 +85928,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1991-05-08",
+        "@type": "xsd:date"
       }
     },
     {
@@ -76446,6 +85963,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1983-01-24",
+        "@type": "xsd:date"
       }
     },
     {
@@ -76482,7 +86003,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2001-01-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32012L0004",
@@ -76513,6 +86038,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2012-04-04",
+        "@type": "xsd:date"
       }
     },
     {
@@ -76544,6 +86073,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1983-01-24",
+        "@type": "xsd:date"
       }
     },
     {
@@ -76575,6 +86108,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -76606,6 +86143,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2000-06-05",
+        "@type": "xsd:date"
       }
     },
     {
@@ -76637,6 +86178,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2014-03-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -76668,6 +86213,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2000-08-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -76699,6 +86248,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1982-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -76730,6 +86283,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2013-11-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -76761,6 +86318,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1996-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -76792,6 +86353,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1979-06-29",
+        "@type": "xsd:date"
       }
     },
     {
@@ -76823,6 +86388,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -76854,6 +86423,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2014-05-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -76949,7 +86522,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2001-01-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31989L0595",
@@ -76980,6 +86557,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1991-10-13",
+        "@type": "xsd:date"
       }
     },
     {
@@ -77011,6 +86592,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2005-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -77042,6 +86627,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -77078,7 +86667,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1999-12-11",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31978L0386",
@@ -77109,6 +86702,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1980-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -77140,6 +86737,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2015-08-14",
+        "@type": "xsd:date"
       }
     },
     {
@@ -77171,6 +86772,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1987-10-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -77202,6 +86807,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1977-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -77233,6 +86842,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1981-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -77269,7 +86882,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2000-07-21",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32007L0065",
@@ -77305,7 +86922,16 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:MEEDIA_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2009-12-19",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31994L0005",
@@ -77336,6 +86962,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1995-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -77367,6 +86997,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-07-23",
+        "@type": "xsd:date"
       }
     },
     {
@@ -77398,6 +87032,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -77434,7 +87072,16 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:MERA_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2009-11-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31990L0121",
@@ -77465,6 +87112,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1990-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -77496,6 +87147,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1990-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -77527,6 +87182,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2003-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -77558,6 +87217,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2000-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -77589,6 +87252,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2008-12-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -77656,6 +87323,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2017-05-24",
+        "@type": "xsd:date"
       }
     },
     {
@@ -77692,7 +87363,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2016-03-21",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32008L0027",
@@ -77759,6 +87434,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1970-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -77790,6 +87469,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-09-23",
+        "@type": "xsd:date"
       }
     },
     {
@@ -77821,6 +87504,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -77857,7 +87544,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2014-12-31",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31983L0635",
@@ -77888,6 +87579,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1986-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -77919,6 +87614,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -77950,6 +87649,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1978-12-29",
+        "@type": "xsd:date"
       }
     },
     {
@@ -77986,7 +87689,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2016-04-19",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32004L0097",
@@ -78048,6 +87755,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-11-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -78115,6 +87826,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1990-06-20",
+        "@type": "xsd:date"
       }
     },
     {
@@ -78146,6 +87861,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1984-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -78177,6 +87896,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1982-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -78239,6 +87962,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1987-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -78275,7 +88002,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2004-08-12",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31989L0117",
@@ -78306,6 +88037,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1991-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -78337,6 +88072,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1971-12-09",
+        "@type": "xsd:date"
       }
     },
     {
@@ -78373,7 +88112,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2004-09-10",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31998L0091",
@@ -78409,7 +88152,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2000-01-16",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32010L0003",
@@ -78440,6 +88187,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2010-09-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -78471,6 +88222,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -78502,6 +88257,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -78564,6 +88323,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2010-02-28",
+        "@type": "xsd:date"
       }
     },
     {
@@ -78600,7 +88363,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2015-07-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32008L0095",
@@ -78636,7 +88403,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1992-12-31",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31977L0096",
@@ -78667,6 +88438,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1979-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -78698,6 +88473,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1996-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -78796,6 +88575,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2012-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -78827,6 +88615,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2009-11-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -78858,6 +88650,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2014-07-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -78894,7 +88690,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2013-10-31",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31986L0562",
@@ -78925,6 +88725,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1986-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -78956,6 +88760,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -79018,6 +88826,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2012-01-18",
+        "@type": "xsd:date"
       }
     },
     {
@@ -79054,7 +88866,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2013-12-25",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31983L0467",
@@ -79085,6 +88901,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1984-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -79116,6 +88936,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1984-06-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -79147,6 +88971,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-11-08",
+        "@type": "xsd:date"
       }
     },
     {
@@ -79178,6 +89006,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2014-01-28",
+        "@type": "xsd:date"
       }
     },
     {
@@ -79209,6 +89041,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2011-07-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -79245,7 +89086,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2008-06-10",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32015L2203",
@@ -79281,7 +89126,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2016-12-22",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32004L0072",
@@ -79312,6 +89161,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-10-12",
+        "@type": "xsd:date"
       }
     },
     {
@@ -79379,6 +89232,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -79441,6 +89298,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2000-12-25",
+        "@type": "xsd:date"
       }
     },
     {
@@ -79477,7 +89338,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2001-10-21",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31998L0033",
@@ -79513,7 +89378,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2000-07-21",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32007L0010",
@@ -79544,6 +89413,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2008-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -79606,6 +89479,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-12-14",
+        "@type": "xsd:date"
       }
     },
     {
@@ -79637,6 +89514,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2008-03-08",
+        "@type": "xsd:date"
       }
     },
     {
@@ -79668,6 +89549,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1977-03-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -79704,7 +89589,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2013-12-13",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32003L0104",
@@ -79735,6 +89624,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-05-20",
+        "@type": "xsd:date"
       }
     },
     {
@@ -79802,6 +89695,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2005-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -79874,7 +89771,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2015-11-26",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32006L0007",
@@ -79910,7 +89811,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2008-03-24",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31999L0029",
@@ -79972,6 +89877,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1987-11-07",
+        "@type": "xsd:date"
       }
     },
     {
@@ -80003,6 +89912,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-07-08",
+        "@type": "xsd:date"
       }
     },
     {
@@ -80065,6 +89978,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -80101,7 +90018,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2005-10-08",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31995L0028",
@@ -80137,7 +90058,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1997-04-24",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32006L0018",
@@ -80199,6 +90124,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1975-06-19",
+        "@type": "xsd:date"
       }
     },
     {
@@ -80230,6 +90159,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2002-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -80261,6 +90194,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1972-01-28",
+        "@type": "xsd:date"
       }
     },
     {
@@ -80292,6 +90229,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1987-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -80359,6 +90300,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2016-05-12",
+        "@type": "xsd:date"
       }
     },
     {
@@ -80390,6 +90335,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1974-08-28",
+        "@type": "xsd:date"
       }
     },
     {
@@ -80421,6 +90370,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-12-14",
+        "@type": "xsd:date"
       }
     },
     {
@@ -80452,6 +90405,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2000-01-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -80483,6 +90440,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:TPSKS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2011-11-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -80514,6 +90480,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1978-12-29",
+        "@type": "xsd:date"
       }
     },
     {
@@ -80576,6 +90546,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1983-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -80607,6 +90581,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1982-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -80638,6 +90616,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:TPSKS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2010-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -80669,6 +90656,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -80700,6 +90691,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -80767,6 +90762,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -80798,6 +90797,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1984-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -80897,7 +90900,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2017-05-20",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32008L0124",
@@ -80928,6 +90935,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1976-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -80959,6 +90970,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1991-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -80990,6 +91005,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1998-12-16",
+        "@type": "xsd:date"
       }
     },
     {
@@ -81021,6 +91040,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1969-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -81052,6 +91075,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2000-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -81083,6 +91110,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-11-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -81114,6 +91145,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1980-04-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -81145,6 +91180,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2009-10-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -81279,7 +91318,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2000-09-20",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31975L0431",
@@ -81310,6 +91353,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1977-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -81341,6 +91388,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-01-22",
+        "@type": "xsd:date"
       }
     },
     {
@@ -81372,6 +91423,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-03-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -81403,6 +91458,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-04-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -81434,6 +91493,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2009-07-21",
+        "@type": "xsd:date"
       }
     },
     {
@@ -81465,6 +91528,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1988-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -81496,6 +91563,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2005-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -81527,6 +91598,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:RAUDTEE_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2010-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -81558,6 +91638,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2014-07-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -81589,6 +91673,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1977-12-19",
+        "@type": "xsd:date"
       }
     },
     {
@@ -81620,6 +91708,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1989-06-26",
+        "@type": "xsd:date"
       }
     },
     {
@@ -81651,6 +91743,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1990-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -81682,6 +91778,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2012-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -81713,6 +91813,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2016-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -81744,6 +91848,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1998-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -81775,6 +91883,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2010-09-15",
+        "@type": "xsd:date"
       }
     },
     {
@@ -81811,7 +91923,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1997-09-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31978L0549",
@@ -81842,6 +91958,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1979-12-15",
+        "@type": "xsd:date"
       }
     },
     {
@@ -81873,6 +91993,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -81904,6 +92028,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2003-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -81935,6 +92063,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1995-12-14",
+        "@type": "xsd:date"
       }
     },
     {
@@ -82002,7 +92134,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1997-12-31",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31996L0054",
@@ -82033,6 +92169,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1997-10-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -82095,6 +92235,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -82126,6 +92270,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1987-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -82162,7 +92310,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2006-02-21",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31982L0176",
@@ -82193,6 +92345,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1983-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -82224,6 +92380,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2010-12-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -82255,6 +92415,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1985-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -82286,6 +92450,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-12-29",
+        "@type": "xsd:date"
       }
     },
     {
@@ -82317,6 +92485,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1988-10-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -82348,6 +92520,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2003-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -82379,6 +92555,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-03-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -82451,7 +92631,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2012-09-23",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31993L0062",
@@ -82482,6 +92666,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -82513,6 +92701,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-10-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -82544,6 +92736,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2008-01-18",
+        "@type": "xsd:date"
       }
     },
     {
@@ -82575,6 +92771,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2014-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -82606,6 +92806,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2010-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -82637,6 +92841,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2010-12-10",
+        "@type": "xsd:date"
       }
     },
     {
@@ -82668,6 +92876,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2010-01-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -82699,6 +92911,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2010-05-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -82730,6 +92946,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1982-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -82766,7 +92986,19 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:MSOS_Map_2026"
+        },
+        {
+          "@id": "estleg:MERESOIT_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2012-01-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32010L0002",
@@ -82797,6 +93029,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2010-05-28",
+        "@type": "xsd:date"
       }
     },
     {
@@ -82828,6 +93064,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2003-07-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -82859,6 +93099,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -82890,6 +93134,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2010-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -82921,6 +93169,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1976-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -82952,6 +93204,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2014-12-04",
+        "@type": "xsd:date"
       }
     },
     {
@@ -82983,6 +93239,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2015-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -83014,6 +93274,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -83045,6 +93309,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2010-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -83076,6 +93344,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1991-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -83107,6 +93379,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1976-11-21",
+        "@type": "xsd:date"
       }
     },
     {
@@ -83138,6 +93414,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2010-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -83169,6 +93449,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2010-04-06",
+        "@type": "xsd:date"
       }
     },
     {
@@ -83205,7 +93489,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2003-06-30",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31999L0067",
@@ -83267,6 +93555,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-03-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -83361,6 +93653,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2008-12-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -83392,6 +93688,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1991-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -83423,6 +93723,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -83454,6 +93758,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-04-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -83485,6 +93793,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1998-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -83516,6 +93828,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -83547,6 +93863,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:TaimKS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2011-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -83609,6 +93934,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1997-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -83640,6 +93969,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1988-11-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -83671,6 +94004,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -83733,6 +94070,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2016-01-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -83769,7 +94110,16 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2010-09-30",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32007L0051",
@@ -83805,7 +94155,16 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:MEDITS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2008-10-09",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31982L0443",
@@ -83836,6 +94195,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1983-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -83867,6 +94230,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2009-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -83903,7 +94270,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2004-03-31",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31962L0302",
@@ -83965,6 +94336,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1998-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -83996,6 +94371,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-02-10",
+        "@type": "xsd:date"
       }
     },
     {
@@ -84027,6 +94406,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2005-10-19",
+        "@type": "xsd:date"
       }
     },
     {
@@ -84320,7 +94703,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2004-05-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32004L0084",
@@ -84418,7 +94805,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1990-06-20",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31989L0321",
@@ -84449,6 +94840,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1989-09-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -84480,6 +94875,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2016-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -84656,6 +95055,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2008-09-14",
+        "@type": "xsd:date"
       }
     },
     {
@@ -84687,6 +95090,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2018-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -84754,7 +95161,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1002-02-02",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32012L0048",
@@ -84785,6 +95196,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2013-12-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -84816,6 +95231,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -84847,6 +95266,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2003-06-29",
+        "@type": "xsd:date"
       }
     },
     {
@@ -84878,6 +95301,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1997-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -84909,6 +95336,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2010-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -84940,6 +95376,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1977-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -84971,6 +95411,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-12-06",
+        "@type": "xsd:date"
       }
     },
     {
@@ -85002,6 +95446,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1988-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -85038,7 +95486,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1999-12-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31976L0580",
@@ -85105,7 +95557,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2009-01-05",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31989L0427",
@@ -85136,6 +95592,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1991-01-11",
+        "@type": "xsd:date"
       }
     },
     {
@@ -85167,6 +95627,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-11-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -85229,6 +95693,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-01-22",
+        "@type": "xsd:date"
       }
     },
     {
@@ -85260,6 +95728,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1981-06-16",
+        "@type": "xsd:date"
       }
     },
     {
@@ -85291,6 +95763,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -85322,6 +95798,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1979-11-26",
+        "@type": "xsd:date"
       }
     },
     {
@@ -85353,6 +95833,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1985-08-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -85470,6 +95954,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1997-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -85501,6 +95989,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -85532,6 +96024,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2012-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -85563,6 +96064,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -85594,6 +96099,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1971-12-08",
+        "@type": "xsd:date"
       }
     },
     {
@@ -85630,7 +96139,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1998-10-27",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32013L0009",
@@ -85661,6 +96174,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2014-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -85692,6 +96209,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1990-12-29",
+        "@type": "xsd:date"
       }
     },
     {
@@ -85723,6 +96244,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1988-09-21",
+        "@type": "xsd:date"
       }
     },
     {
@@ -85754,6 +96279,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1981-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -85785,6 +96314,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-06-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -85816,6 +96349,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-07-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -85847,6 +96384,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -85878,6 +96419,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -85909,6 +96454,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1992-04-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -85940,6 +96489,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2013-04-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -85971,6 +96529,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -86002,6 +96564,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1974-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -86069,6 +96635,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2014-07-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -86100,6 +96670,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -86131,6 +96705,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2015-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -86162,6 +96740,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2014-06-05",
+        "@type": "xsd:date"
       }
     },
     {
@@ -86229,6 +96811,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-11-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -86260,6 +96846,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -86291,6 +96881,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1984-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -86322,6 +96916,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1995-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -86353,6 +96951,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1996-10-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -86384,6 +96986,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1981-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -86415,6 +97021,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1995-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -86477,6 +97087,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -86513,7 +97127,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2001-05-31",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32011L0022",
@@ -86544,6 +97162,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2012-01-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -86575,6 +97197,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-05-17",
+        "@type": "xsd:date"
       }
     },
     {
@@ -86637,6 +97263,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -86735,6 +97365,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2016-04-19",
+        "@type": "xsd:date"
       }
     },
     {
@@ -86766,6 +97400,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -86797,6 +97435,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1988-12-03",
+        "@type": "xsd:date"
       }
     },
     {
@@ -86828,6 +97470,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2011-01-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -86859,6 +97510,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2014-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -86890,6 +97545,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1995-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -86921,6 +97580,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1996-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -86952,6 +97615,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2010-08-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -86983,6 +97655,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-10-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -87014,6 +97690,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2011-01-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -87045,6 +97730,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2011-01-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -87076,6 +97770,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2011-01-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -87107,6 +97810,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -87138,6 +97845,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-10-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -87169,6 +97880,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1988-01-15",
+        "@type": "xsd:date"
       }
     },
     {
@@ -87200,6 +97915,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-03-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -87231,6 +97950,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-10-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -87298,7 +98021,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1001-01-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32004L0026",
@@ -87334,7 +98061,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2005-05-20",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32008L0031",
@@ -87432,6 +98163,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1990-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -87463,6 +98198,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -87494,6 +98233,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1979-02-02",
+        "@type": "xsd:date"
       }
     },
     {
@@ -87525,6 +98268,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2010-08-15",
+        "@type": "xsd:date"
       }
     },
     {
@@ -87556,6 +98303,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1984-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -87673,6 +98424,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -87740,6 +98495,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -87802,6 +98561,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1997-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -87833,6 +98596,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2009-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -87864,6 +98631,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2012-07-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -87926,6 +98697,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-09-03",
+        "@type": "xsd:date"
       }
     },
     {
@@ -87962,7 +98737,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2004-08-11",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31991L0287",
@@ -87993,6 +98772,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1991-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -88024,6 +98807,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1972-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -88055,6 +98842,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2017-10-27",
+        "@type": "xsd:date"
       }
     },
     {
@@ -88086,6 +98877,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -88117,6 +98912,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1995-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -88148,6 +98947,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1988-11-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -88179,6 +98982,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2009-08-05",
+        "@type": "xsd:date"
       }
     },
     {
@@ -88210,6 +99017,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2000-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -88241,6 +99052,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2000-02-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -88272,6 +99087,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1995-03-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -88303,6 +99122,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-11-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -88447,6 +99270,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2008-04-04",
+        "@type": "xsd:date"
       }
     },
     {
@@ -88478,6 +99305,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2014-07-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -88509,6 +99340,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1979-03-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -88540,6 +99375,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2016-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -88643,6 +99482,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1998-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -88679,7 +99522,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2006-09-08",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31981L0855",
@@ -89059,7 +99906,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2003-05-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31998L0075",
@@ -89090,6 +99941,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-02-27",
+        "@type": "xsd:date"
       }
     },
     {
@@ -89121,6 +99976,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1978-12-20",
+        "@type": "xsd:date"
       }
     },
     {
@@ -89152,6 +100011,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1982-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -89188,7 +100051,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2018-05-21",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32001L0114",
@@ -89250,6 +100117,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2013-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -89281,6 +100152,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2014-01-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -89312,6 +100192,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1982-01-17",
+        "@type": "xsd:date"
       }
     },
     {
@@ -89379,6 +100263,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1975-05-26",
+        "@type": "xsd:date"
       }
     },
     {
@@ -89410,6 +100298,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2010-04-15",
+        "@type": "xsd:date"
       }
     },
     {
@@ -89441,6 +100333,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2005-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -89472,6 +100368,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2005-08-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -89503,6 +100403,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2013-01-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -89534,6 +100443,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2013-04-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -89565,6 +100483,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2011-07-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -89596,6 +100523,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1002-02-02",
+        "@type": "xsd:date"
       }
     },
     {
@@ -89632,7 +100563,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2000-07-30",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32013L0007",
@@ -89663,6 +100598,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2014-01-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -89694,6 +100638,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1997-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -89725,6 +100673,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2014-01-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -89756,6 +100713,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2012-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -89787,6 +100753,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2014-01-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -89823,7 +100798,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2005-12-31",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32011L0011",
@@ -89854,6 +100833,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2012-01-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -89885,6 +100873,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2013-01-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -89916,6 +100913,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2012-01-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -89947,6 +100953,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2014-10-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -89983,7 +100993,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2002-10-17",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32006L0112R07",
@@ -90159,6 +101173,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-12-15",
+        "@type": "xsd:date"
       }
     },
     {
@@ -90195,7 +101213,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2000-04-21",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31999L0026",
@@ -90226,6 +101248,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -90257,6 +101283,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2014-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -90319,6 +101349,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2012-06-24",
+        "@type": "xsd:date"
       }
     },
     {
@@ -90350,6 +101384,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-11-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -90386,7 +101424,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2014-12-28",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31978L0365",
@@ -90448,6 +101490,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -90510,6 +101556,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:VSS_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2005-12-05",
+        "@type": "xsd:date"
       }
     },
     {
@@ -90541,6 +101596,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-09-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -90577,7 +101636,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2015-06-24",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32006L0079",
@@ -90608,6 +101671,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1979-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -90639,6 +101706,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2014-07-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -90670,6 +101741,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -90701,6 +101776,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2009-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -90732,6 +101811,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1973-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -90763,6 +101846,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -90949,6 +102036,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1984-11-19",
+        "@type": "xsd:date"
       }
     },
     {
@@ -90980,6 +102071,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-01-29",
+        "@type": "xsd:date"
       }
     },
     {
@@ -91016,7 +102111,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1996-07-18",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32015L0573",
@@ -91047,6 +102146,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2016-01-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -91083,7 +102186,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2016-09-18",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32007L0007",
@@ -91114,6 +102221,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-01-20",
+        "@type": "xsd:date"
       }
     },
     {
@@ -91145,6 +102256,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1980-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -91207,6 +102322,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1983-05-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -91238,6 +102357,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2016-03-28",
+        "@type": "xsd:date"
       }
     },
     {
@@ -91269,6 +102392,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-06-14",
+        "@type": "xsd:date"
       }
     },
     {
@@ -91300,6 +102427,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1991-03-21",
+        "@type": "xsd:date"
       }
     },
     {
@@ -91331,6 +102462,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -91367,7 +102502,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2004-09-15",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31975L0409",
@@ -91398,6 +102537,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1976-06-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -91682,6 +102825,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1973-11-24",
+        "@type": "xsd:date"
       }
     },
     {
@@ -91713,6 +102860,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1988-04-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -91744,6 +102895,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1991-10-18",
+        "@type": "xsd:date"
       }
     },
     {
@@ -91775,6 +102930,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-06-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -91806,6 +102965,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2010-08-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -91837,6 +103005,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2008-10-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -91868,6 +103040,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2010-06-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -91899,6 +103075,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1968-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -91930,6 +103110,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1995-05-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -91966,7 +103150,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2000-12-04",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31986L0594",
@@ -91997,6 +103185,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1989-12-04",
+        "@type": "xsd:date"
       }
     },
     {
@@ -92028,6 +103220,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-03-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -92095,6 +103291,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1987-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -92126,6 +103326,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1991-01-03",
+        "@type": "xsd:date"
       }
     },
     {
@@ -92157,6 +103361,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2013-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -92188,6 +103396,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1976-06-20",
+        "@type": "xsd:date"
       }
     },
     {
@@ -92219,6 +103431,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-11-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -92250,6 +103466,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1970-02-02",
+        "@type": "xsd:date"
       }
     },
     {
@@ -92281,6 +103501,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2013-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -92312,6 +103536,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-11-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -92343,6 +103571,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-10-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -92374,6 +103606,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-04-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -92446,7 +103682,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2019-01-14",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32009L0097",
@@ -92477,6 +103717,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2009-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -92508,6 +103752,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-11-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -92539,6 +103787,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-04-20",
+        "@type": "xsd:date"
       }
     },
     {
@@ -92597,6 +103849,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-09-03",
+        "@type": "xsd:date"
       }
     },
     {
@@ -92628,6 +103884,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-04-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -92659,6 +103919,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -92690,6 +103954,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1990-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -92752,6 +104020,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-09-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -92783,6 +104055,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2012-05-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -92814,6 +104090,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2009-10-29",
+        "@type": "xsd:date"
       }
     },
     {
@@ -92845,6 +104125,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2014-07-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -92876,6 +104160,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-02-16",
+        "@type": "xsd:date"
       }
     },
     {
@@ -92907,6 +104195,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2005-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -92938,6 +104230,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1998-04-07",
+        "@type": "xsd:date"
       }
     },
     {
@@ -92969,6 +104265,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1983-11-25",
+        "@type": "xsd:date"
       }
     },
     {
@@ -93000,6 +104300,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1995-08-08",
+        "@type": "xsd:date"
       }
     },
     {
@@ -93036,7 +104340,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2009-01-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32001L0104",
@@ -93103,6 +104411,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1991-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -93134,6 +104446,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2009-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -93165,6 +104481,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -93196,6 +104516,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1994-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -93232,7 +104556,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2016-02-29",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_31984L0425",
@@ -93263,6 +104591,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1985-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -93294,6 +104626,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -93325,6 +104661,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1997-05-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -93356,6 +104696,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-12-27",
+        "@type": "xsd:date"
       }
     },
     {
@@ -93387,6 +104731,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2009-03-07",
+        "@type": "xsd:date"
       }
     },
     {
@@ -93418,6 +104766,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -93480,6 +104832,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1993-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -93511,6 +104867,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1981-12-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -93542,6 +104902,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2013-12-21",
+        "@type": "xsd:date"
       }
     },
     {
@@ -93573,6 +104937,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1998-12-15",
+        "@type": "xsd:date"
       }
     },
     {
@@ -93636,6 +105004,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1976-12-21",
+        "@type": "xsd:date"
       }
     },
     {
@@ -93667,6 +105039,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1964-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -93698,6 +105074,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1996-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -93729,6 +105109,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-11-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -93760,6 +105144,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-11-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -93791,6 +105179,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-11-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -93822,6 +105214,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-12-04",
+        "@type": "xsd:date"
       }
     },
     {
@@ -93853,6 +105249,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-03-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -93915,6 +105315,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-02-28",
+        "@type": "xsd:date"
       }
     },
     {
@@ -93946,6 +105350,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1984-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -93977,6 +105385,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2008-08-16",
+        "@type": "xsd:date"
       }
     },
     {
@@ -94008,6 +105420,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1989-03-24",
+        "@type": "xsd:date"
       }
     },
     {
@@ -94039,6 +105455,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-11-08",
+        "@type": "xsd:date"
       }
     },
     {
@@ -94106,6 +105526,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-11-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -94137,6 +105561,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-12-18",
+        "@type": "xsd:date"
       }
     },
     {
@@ -94168,6 +105596,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-08-21",
+        "@type": "xsd:date"
       }
     },
     {
@@ -94199,6 +105631,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-05-10",
+        "@type": "xsd:date"
       }
     },
     {
@@ -94230,6 +105666,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2008-01-20",
+        "@type": "xsd:date"
       }
     },
     {
@@ -94261,6 +105701,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-12-08",
+        "@type": "xsd:date"
       }
     },
     {
@@ -94292,6 +105736,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2000-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -94323,6 +105771,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2010-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -94440,6 +105892,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2000-11-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -94471,6 +105927,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2016-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -94529,6 +105989,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:RAUDTEE_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2010-06-18",
+        "@type": "xsd:date"
       }
     },
     {
@@ -94560,6 +106029,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2001-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -94591,6 +106064,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1998-10-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -94622,6 +106099,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2005-02-28",
+        "@type": "xsd:date"
       }
     },
     {
@@ -94653,6 +106134,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2004-04-20",
+        "@type": "xsd:date"
       }
     },
     {
@@ -94684,6 +106169,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1981-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -94715,6 +106204,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1999-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -94746,6 +106239,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2007-03-23",
+        "@type": "xsd:date"
       }
     },
     {
@@ -94777,6 +106274,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1998-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -94808,6 +106309,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2003-03-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -94839,6 +106344,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2003-06-15",
+        "@type": "xsd:date"
       }
     },
     {
@@ -94870,6 +106379,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2003-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -94932,6 +106445,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-11-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -94963,6 +106480,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2013-07-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -95035,7 +106556,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2007-02-24",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32004L0014",
@@ -95066,6 +106591,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2005-07-29",
+        "@type": "xsd:date"
       }
     },
     {
@@ -95128,6 +106657,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2003-06-15",
+        "@type": "xsd:date"
       }
     },
     {
@@ -95159,6 +106692,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2001-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -95190,6 +106727,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1998-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -95221,6 +106762,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2009-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -95252,6 +106802,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2014-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -95288,7 +106842,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1989-01-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32008L0020",
@@ -95468,6 +107026,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1986-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -95499,6 +107061,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2006-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -95530,6 +107096,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2010-02-19",
+        "@type": "xsd:date"
       }
     },
     {
@@ -95561,6 +107136,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -95592,6 +107171,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2011-11-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -95623,6 +107206,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1996-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -95654,6 +107241,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2009-03-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -95685,6 +107281,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2012-01-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -95716,6 +107316,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2014-07-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -95778,6 +107382,15 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transposedBy": [
+        {
+          "@id": "estleg:BIOTSI_Map_2026"
+        }
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2010-08-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -96000,6 +107613,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_EuropeanCommission"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1998-08-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -96807,7 +108424,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2025-09-29",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32024L0505",
@@ -96843,7 +108464,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2025-03-04",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32024L3237",
@@ -96879,7 +108504,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2027-07-20",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32023L2123",
@@ -96915,7 +108544,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2025-11-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32023L2226",
@@ -96946,6 +108579,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2025-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -96982,7 +108619,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2025-11-20",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32023L2413",
@@ -97018,7 +108659,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2024-07-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32023L2864",
@@ -97054,7 +108699,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2025-07-10",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32023L2843",
@@ -97090,7 +108739,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1001-01-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32024L0927",
@@ -97126,7 +108779,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2026-04-16",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32024L1069",
@@ -97162,7 +108819,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2026-05-07",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32024L1438",
@@ -97198,7 +108859,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2025-12-14",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32024L1385",
@@ -97234,7 +108899,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2027-06-14",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32024L1712",
@@ -97270,7 +108939,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2026-07-15",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32023L2673",
@@ -97306,7 +108979,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2025-12-19",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32023L2661",
@@ -97342,7 +109019,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2025-03-21",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32023L2668",
@@ -97378,7 +109059,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2025-12-21",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32024L0825",
@@ -97414,7 +109099,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2026-03-27",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32025L1237",
@@ -97450,7 +109139,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2027-01-15",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32024L0869",
@@ -97486,7 +109179,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2026-04-09",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32024L0884",
@@ -97522,7 +109219,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2025-10-09",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32024L1174",
@@ -97558,7 +109259,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2024-11-13",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32024L1203",
@@ -97594,7 +109299,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2026-05-21",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32024L1233",
@@ -97630,7 +109339,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2026-05-21",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32024L1265",
@@ -97661,6 +109374,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2025-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -97697,7 +109414,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2026-11-23",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32024L1226",
@@ -97733,7 +109454,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2025-05-20",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32012L0037R01",
@@ -98091,7 +109816,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2025-01-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32024L1346",
@@ -98127,7 +109856,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2026-06-12",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32024L1500",
@@ -98163,7 +109896,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2026-06-19",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32024L1499",
@@ -98194,6 +109931,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2026-06-19",
+        "@type": "xsd:date"
       }
     },
     {
@@ -98230,7 +109971,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2027-07-10",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32024L1640",
@@ -98266,7 +110011,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2025-07-10",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32024L1619",
@@ -98302,7 +110051,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2026-01-10",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32024L1711",
@@ -98338,7 +110091,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2025-01-17",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32024L1760",
@@ -98374,7 +110131,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2028-07-26",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32024L1799",
@@ -98410,7 +110171,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2026-07-31",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32024L1785",
@@ -98446,7 +110211,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2026-07-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32024L1788",
@@ -98482,7 +110251,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2026-08-05",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32024L2811",
@@ -98518,7 +110291,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2026-06-05",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32024L2841",
@@ -98554,7 +110331,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2027-06-05",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32024L2842",
@@ -98590,7 +110371,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2027-06-05",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32024L2810",
@@ -98626,7 +110411,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2026-12-05",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32024L2808",
@@ -98698,7 +110487,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2025-11-28",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32024L2749",
@@ -98734,7 +110527,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2026-05-29",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32024L2831",
@@ -98770,7 +110567,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2026-12-02",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32024L2823",
@@ -98806,7 +110607,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2027-12-09",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32024L2853",
@@ -98842,7 +110647,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2026-12-09",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32024L3017",
@@ -98878,7 +110687,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2027-06-27",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32024L2994",
@@ -98914,7 +110727,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2026-06-25",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32024L3019",
@@ -98950,7 +110767,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2027-07-31",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32024L3101",
@@ -98986,7 +110807,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2027-07-06",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32024L3099",
@@ -99022,7 +110847,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2027-07-06",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32024L3100",
@@ -99058,7 +110887,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2027-07-06",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32025L0002",
@@ -99094,7 +110927,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2027-01-29",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32025L0001",
@@ -99130,7 +110967,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2027-01-29",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32025L0050",
@@ -99161,6 +111002,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2028-12-31",
+        "@type": "xsd:date"
       }
     },
     {
@@ -99197,7 +111042,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2027-07-31",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32025L0425",
@@ -99228,6 +111077,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2031-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -99259,6 +111112,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2025-04-14",
+        "@type": "xsd:date"
       }
     },
     {
@@ -99295,7 +111152,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2025-12-31",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32025L2647",
@@ -99331,7 +111192,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2028-03-20",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32025L0872",
@@ -99362,6 +111227,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "1001-01-01",
+        "@type": "xsd:date"
       }
     },
     {
@@ -99393,6 +111262,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2027-09-29",
+        "@type": "xsd:date"
       }
     },
     {
@@ -99424,6 +111297,10 @@
       },
       "estleg:euInstitution": {
         "@id": "estleg:EUInst_CouncilOfEU"
+      },
+      "estleg:transpositionDeadline": {
+        "@value": "2028-06-30",
+        "@type": "xsd:date"
       }
     },
     {
@@ -99496,7 +111373,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2027-06-17",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32024L2881",
@@ -99528,7 +111409,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2026-12-11",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32025L2205",
@@ -99564,7 +111449,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2027-11-26",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32025L2206",
@@ -99600,7 +111489,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2028-11-26",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32025L2482",
@@ -99636,7 +111529,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2029-01-02",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32025L2456",
@@ -99708,7 +111605,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2028-12-17",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32025L2459",
@@ -99744,7 +111645,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "1001-01-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32025L2450",
@@ -99780,7 +111685,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2028-01-01",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32026L0288",
@@ -99816,7 +111725,11 @@
         {
           "@id": "estleg:EUInst_DG_ENV"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2028-03-02",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32026L0192",
@@ -99852,7 +111765,11 @@
         {
           "@id": "estleg:EUInst_DG_GROW"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2026-07-29",
+        "@type": "xsd:date"
+      }
     },
     {
       "@id": "estleg:EU_32026L0470",
@@ -99888,7 +111805,11 @@
         {
           "@id": "estleg:EUInst_EuropeanParliament"
         }
-      ]
+      ],
+      "estleg:transpositionDeadline": {
+        "@value": "2027-03-19",
+        "@type": "xsd:date"
+      }
     }
   ]
 }

--- a/krr_outputs/euroopa_liidu_teenuste_direktiivi_rakendamise_seadus_peep.json
+++ b/krr_outputs/euroopa_liidu_teenuste_direktiivi_rakendamise_seadus_peep.json
@@ -36,7 +36,13 @@
         {
           "@id": "http://eurovoc.europa.eu/3606"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32006L0123"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_TDRS",

--- a/krr_outputs/finantsinspektsiooni_seadus_peep.json
+++ b/krr_outputs/finantsinspektsiooni_seadus_peep.json
@@ -91,7 +91,19 @@
         {
           "@id": "http://eurovoc.europa.eu/0411"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32015L2392"
+        },
+        {
+          "@id": "estleg:EU_32009L0111"
+        },
+        {
+          "@id": "estleg:EU_32009L0110"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_FIS",

--- a/krr_outputs/geneetiliselt_muundatud_organismide_keskkonda_viimise_seadus_peep.json
+++ b/krr_outputs/geneetiliselt_muundatud_organismide_keskkonda_viimise_seadus_peep.json
@@ -64,7 +64,13 @@
         {
           "@id": "http://eurovoc.europa.eu/5216"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32008L0090"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_GMOVS",

--- a/krr_outputs/hadaolukorra_seadus_peep.json
+++ b/krr_outputs/hadaolukorra_seadus_peep.json
@@ -601,7 +601,13 @@
         {
           "@id": "http://eurovoc.europa.eu/2431"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32008L0114"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_HADAOL",

--- a/krr_outputs/halduskohtumenetluse_seadustik_peep.json
+++ b/krr_outputs/halduskohtumenetluse_seadustik_peep.json
@@ -88,7 +88,16 @@
         {
           "@id": "http://eurovoc.europa.eu/2451"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32008L0001"
+        },
+        {
+          "@id": "estleg:EU_32004L0049"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_HALDUS",

--- a/krr_outputs/halduskoostoo_seadus_peep.json
+++ b/krr_outputs/halduskoostoo_seadus_peep.json
@@ -88,7 +88,13 @@
         {
           "@id": "http://eurovoc.europa.eu/5211"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32003L0098"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_HKTS",

--- a/krr_outputs/haldusmenetluse_peep.json
+++ b/krr_outputs/haldusmenetluse_peep.json
@@ -323,7 +323,19 @@
         {
           "@id": "http://eurovoc.europa.eu/2431"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32004L0049"
+        },
+        {
+          "@id": "estleg:EU_32003L0098"
+        },
+        {
+          "@id": "estleg:EU_32009L0052"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_HMS",

--- a/krr_outputs/individuaalse_toovaidluse_lahendamise_seadus_peep.json
+++ b/krr_outputs/individuaalse_toovaidluse_lahendamise_seadus_peep.json
@@ -44,7 +44,13 @@
         {
           "@id": "http://eurovoc.europa.eu/2441"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32009L0052"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_ITVS",

--- a/krr_outputs/infouhiskonna_teenuse_seadus_peep.json
+++ b/krr_outputs/infouhiskonna_teenuse_seadus_peep.json
@@ -64,7 +64,13 @@
         {
           "@id": "http://eurovoc.europa.eu/2421"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32009L0136"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_InfoTS",

--- a/krr_outputs/investeerimisfondide_seadus_peep.json
+++ b/krr_outputs/investeerimisfondide_seadus_peep.json
@@ -88,7 +88,22 @@
         {
           "@id": "http://eurovoc.europa.eu/3606"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32007L0044"
+        },
+        {
+          "@id": "estleg:EU_32010L0078"
+        },
+        {
+          "@id": "estleg:EU_32009L0109"
+        },
+        {
+          "@id": "estleg:EU_32009L0111"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_INVEST",

--- a/krr_outputs/isikuandmete_kaitse_seadus_peep.json
+++ b/krr_outputs/isikuandmete_kaitse_seadus_peep.json
@@ -49,7 +49,19 @@
         {
           "@id": "http://eurovoc.europa.eu/2416"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32003L0098"
+        },
+        {
+          "@id": "estleg:EU_32009L0018"
+        },
+        {
+          "@id": "estleg:EU_32008L0048"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_ISIKUA",

--- a/krr_outputs/jaatmeseadus_peep.json
+++ b/krr_outputs/jaatmeseadus_peep.json
@@ -490,7 +490,28 @@
         {
           "@id": "http://eurovoc.europa.eu/6411"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_31999L0031"
+        },
+        {
+          "@id": "estleg:EU_32006L0021"
+        },
+        {
+          "@id": "estleg:EU_32002L0096"
+        },
+        {
+          "@id": "estleg:EU_32003L0035"
+        },
+        {
+          "@id": "estleg:EU_32008L0098"
+        },
+        {
+          "@id": "estleg:EU_32009L0031"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_JäätS",

--- a/krr_outputs/kaibemaksuseadus_peep.json
+++ b/krr_outputs/kaibemaksuseadus_peep.json
@@ -190,7 +190,31 @@
         {
           "@id": "http://eurovoc.europa.eu/3221"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32008L0008"
+        },
+        {
+          "@id": "estleg:EU_32010L0088"
+        },
+        {
+          "@id": "estleg:EU_32009L0162"
+        },
+        {
+          "@id": "estleg:EU_32010L0066"
+        },
+        {
+          "@id": "estleg:EU_32008L0117"
+        },
+        {
+          "@id": "estleg:EU_32008L0009"
+        },
+        {
+          "@id": "estleg:EU_32009L0069"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_KMS",

--- a/krr_outputs/karistusseadustik_osa1_peep.json
+++ b/krr_outputs/karistusseadustik_osa1_peep.json
@@ -1741,7 +1741,22 @@
         {
           "@id": "http://eurovoc.europa.eu/2431"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32009L0043"
+        },
+        {
+          "@id": "estleg:EU_32009L0052"
+        },
+        {
+          "@id": "estleg:EU_32009L0123"
+        },
+        {
+          "@id": "estleg:EU_32008L0099"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_KARIST_2_osa1",

--- a/krr_outputs/karistusseadustik_osa2_peep.json
+++ b/krr_outputs/karistusseadustik_osa2_peep.json
@@ -1834,7 +1834,22 @@
         {
           "@id": "http://eurovoc.europa.eu/5206"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32009L0043"
+        },
+        {
+          "@id": "estleg:EU_32009L0052"
+        },
+        {
+          "@id": "estleg:EU_32009L0123"
+        },
+        {
+          "@id": "estleg:EU_32008L0099"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_KARIST_2_osa2",

--- a/krr_outputs/kaugkutteseadus_peep.json
+++ b/krr_outputs/kaugkutteseadus_peep.json
@@ -193,7 +193,13 @@
         {
           "@id": "http://eurovoc.europa.eu/1221"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32009L0028"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_KAUGKU",

--- a/krr_outputs/keskkonnamoju_hindamise_ja_keskkonnajuhtimissusteemi_seadus_peep.json
+++ b/krr_outputs/keskkonnamoju_hindamise_ja_keskkonnajuhtimissusteemi_seadus_peep.json
@@ -73,7 +73,16 @@
         {
           "@id": "http://eurovoc.europa.eu/5636"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32001L0042"
+        },
+        {
+          "@id": "estleg:EU_32009L0031"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_KeHJS",

--- a/krr_outputs/keskkonnaregistri_seadus_peep.json
+++ b/krr_outputs/keskkonnaregistri_seadus_peep.json
@@ -36,7 +36,13 @@
         {
           "@id": "http://eurovoc.europa.eu/6411"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32007L0002"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_KeRS",

--- a/krr_outputs/keskkonnavastutuse_seadus_peep.json
+++ b/krr_outputs/keskkonnavastutuse_seadus_peep.json
@@ -36,7 +36,16 @@
         {
           "@id": "http://eurovoc.europa.eu/2421"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32009L0031"
+        },
+        {
+          "@id": "estleg:EU_32000L0060"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_KeVS",

--- a/krr_outputs/kiirgusseadus_peep.json
+++ b/krr_outputs/kiirgusseadus_peep.json
@@ -70,7 +70,16 @@
         {
           "@id": "http://eurovoc.europa.eu/2446"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32009L0071"
+        },
+        {
+          "@id": "estleg:EU_32006L0117"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_KIIRGU",

--- a/krr_outputs/kindlustustegevuse_seadus_peep.json
+++ b/krr_outputs/kindlustustegevuse_seadus_peep.json
@@ -82,7 +82,19 @@
         {
           "@id": "http://eurovoc.europa.eu/5636"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32007L0044"
+        },
+        {
+          "@id": "estleg:EU_32009L0044"
+        },
+        {
+          "@id": "estleg:EU_32009L0109"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_KINDLU",

--- a/krr_outputs/kohaliku_omavalitsuse_peep.json
+++ b/krr_outputs/kohaliku_omavalitsuse_peep.json
@@ -19791,7 +19791,13 @@
         {
           "@id": "http://eurovoc.europa.eu/2441"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32013L0019"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_KOKS",

--- a/krr_outputs/kohtuekspertiisiseadus_peep.json
+++ b/krr_outputs/kohtuekspertiisiseadus_peep.json
@@ -46,7 +46,13 @@
         {
           "@id": "http://eurovoc.europa.eu/6006"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32014L0062"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_KOHTUE",

--- a/krr_outputs/krediidiasutuste_seadus_peep.json
+++ b/krr_outputs/krediidiasutuste_seadus_peep.json
@@ -118,7 +118,31 @@
         {
           "@id": "http://eurovoc.europa.eu/5636"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32009L0110"
+        },
+        {
+          "@id": "estleg:EU_32013L0023"
+        },
+        {
+          "@id": "estleg:EU_32009L0044"
+        },
+        {
+          "@id": "estleg:EU_32009L0109"
+        },
+        {
+          "@id": "estleg:EU_32010L0016"
+        },
+        {
+          "@id": "estleg:EU_32009L0111"
+        },
+        {
+          "@id": "estleg:EU_32010L0076"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_KREDII_2",

--- a/krr_outputs/kutseseadus_peep.json
+++ b/krr_outputs/kutseseadus_peep.json
@@ -36,7 +36,13 @@
         {
           "@id": "http://eurovoc.europa.eu/6006"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32009L0028"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_Kutseseadus",

--- a/krr_outputs/lennundusseadus_peep.json
+++ b/krr_outputs/lennundusseadus_peep.json
@@ -69,7 +69,16 @@
         {
           "@id": "http://eurovoc.europa.eu/0411"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32009L0012"
+        },
+        {
+          "@id": "estleg:EU_32009L0018"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_LENN",

--- a/krr_outputs/liiklusseadus_peep.json
+++ b/krr_outputs/liiklusseadus_peep.json
@@ -160,7 +160,19 @@
         {
           "@id": "http://eurovoc.europa.eu/1221"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32006L0126"
+        },
+        {
+          "@id": "estleg:EU_32009L0004"
+        },
+        {
+          "@id": "estleg:EU_32002L0015"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_LIIKLU_2",

--- a/krr_outputs/lohkematerjaliseadus_peep.json
+++ b/krr_outputs/lohkematerjaliseadus_peep.json
@@ -46,7 +46,13 @@
         {
           "@id": "http://eurovoc.europa.eu/6411"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32007L0023"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_LOHKEM",

--- a/krr_outputs/looduskaitseseadus_peep.json
+++ b/krr_outputs/looduskaitseseadus_peep.json
@@ -64,7 +64,13 @@
         {
           "@id": "http://eurovoc.europa.eu/3611"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_31992L0043"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_LKS",

--- a/krr_outputs/loomakaitseseadus_peep.json
+++ b/krr_outputs/loomakaitseseadus_peep.json
@@ -88,7 +88,13 @@
         {
           "@id": "http://eurovoc.europa.eu/2441"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32007L0043"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_LoKS",

--- a/krr_outputs/loomatauditorje_seadus_peep.json
+++ b/krr_outputs/loomatauditorje_seadus_peep.json
@@ -64,7 +64,13 @@
         {
           "@id": "http://eurovoc.europa.eu/6006"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32008L0073"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_LTTS",

--- a/krr_outputs/maaelu_ja_pollumajandusturu_korraldamise_seadus_peep.json
+++ b/krr_outputs/maaelu_ja_pollumajandusturu_korraldamise_seadus_peep.json
@@ -112,7 +112,13 @@
         {
           "@id": "http://eurovoc.europa.eu/2441"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32008L0090"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_MPK",

--- a/krr_outputs/maakatastriseadus_peep.json
+++ b/krr_outputs/maakatastriseadus_peep.json
@@ -36,7 +36,13 @@
         {
           "@id": "http://eurovoc.europa.eu/5226"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32007L0002"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_MaaKatS",

--- a/krr_outputs/maapoueseadus_peep.json
+++ b/krr_outputs/maapoueseadus_peep.json
@@ -70,7 +70,16 @@
         {
           "@id": "http://eurovoc.europa.eu/1221"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32009L0031"
+        },
+        {
+          "@id": "estleg:EU_32006L0021"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_Maapueseadus",

--- a/krr_outputs/makseasutuste_ja_e_raha_asutuste_seadus_peep.json
+++ b/krr_outputs/makseasutuste_ja_e_raha_asutuste_seadus_peep.json
@@ -36,7 +36,22 @@
         {
           "@id": "http://eurovoc.europa.eu/3606"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32009L0110"
+        },
+        {
+          "@id": "estleg:EU_32009L0065"
+        },
+        {
+          "@id": "estleg:EU_32009L0109"
+        },
+        {
+          "@id": "estleg:EU_32007L0064"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_MERA",

--- a/krr_outputs/maksukorralduse_seadus_peep.json
+++ b/krr_outputs/maksukorralduse_seadus_peep.json
@@ -359,7 +359,16 @@
         {
           "@id": "http://eurovoc.europa.eu/5216"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32011L0016"
+        },
+        {
+          "@id": "estleg:EU_32010L0024"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_MKS",

--- a/krr_outputs/masina_ohutuse_seadus_peep.json
+++ b/krr_outputs/masina_ohutuse_seadus_peep.json
@@ -36,7 +36,13 @@
         {
           "@id": "http://eurovoc.europa.eu/5241"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32009L0127"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_MASINA",

--- a/krr_outputs/meditsiiniseadme_seadus_peep.json
+++ b/krr_outputs/meditsiiniseadme_seadus_peep.json
@@ -76,7 +76,16 @@
         {
           "@id": "http://eurovoc.europa.eu/3606"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32007L0047"
+        },
+        {
+          "@id": "estleg:EU_32007L0051"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_MEDITS",

--- a/krr_outputs/meediateenuste_seadus_peep.json
+++ b/krr_outputs/meediateenuste_seadus_peep.json
@@ -73,7 +73,16 @@
         {
           "@id": "http://eurovoc.europa.eu/2431"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32010L0013"
+        },
+        {
+          "@id": "estleg:EU_32007L0065"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_MEEDIA",

--- a/krr_outputs/meresoidu_seadus_peep.json
+++ b/krr_outputs/meresoidu_seadus_peep.json
@@ -45,7 +45,13 @@
         {
           "@id": "http://eurovoc.europa.eu/6411"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32009L0020"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_MERESOIT",

--- a/krr_outputs/meresoiduohutuse_seadus_peep.json
+++ b/krr_outputs/meresoiduohutuse_seadus_peep.json
@@ -133,7 +133,37 @@
         {
           "@id": "http://eurovoc.europa.eu/2441"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32009L0018"
+        },
+        {
+          "@id": "estleg:EU_32009L0020"
+        },
+        {
+          "@id": "estleg:EU_32011L0015"
+        },
+        {
+          "@id": "estleg:EU_32004L0049"
+        },
+        {
+          "@id": "estleg:EU_32009L0016"
+        },
+        {
+          "@id": "estleg:EU_32009L0021"
+        },
+        {
+          "@id": "estleg:EU_32009L0017"
+        },
+        {
+          "@id": "estleg:EU_32009L0015"
+        },
+        {
+          "@id": "estleg:EU_32010L0036"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_MSOS",

--- a/krr_outputs/mittetulundusuhingute_seadus_peep.json
+++ b/krr_outputs/mittetulundusuhingute_seadus_peep.json
@@ -52,7 +52,13 @@
         {
           "@id": "http://eurovoc.europa.eu/3606"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32008L0122"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_MTÜS",

--- a/krr_outputs/nimeseadus_peep.json
+++ b/krr_outputs/nimeseadus_peep.json
@@ -64,7 +64,13 @@
         {
           "@id": "http://eurovoc.europa.eu/3606"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32007L0002"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_NS",

--- a/krr_outputs/pankrotiseadus_peep.json
+++ b/krr_outputs/pankrotiseadus_peep.json
@@ -37,7 +37,13 @@
         {
           "@id": "http://eurovoc.europa.eu/2441"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32009L0044"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_pankrotiseadus",

--- a/krr_outputs/planeerimisseadus_peep.json
+++ b/krr_outputs/planeerimisseadus_peep.json
@@ -364,7 +364,16 @@
         {
           "@id": "http://eurovoc.europa.eu/0431"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32005L0036"
+        },
+        {
+          "@id": "estleg:EU_32009L0028"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_PLANEE_2",

--- a/krr_outputs/raamatupidamise_seadus_peep.json
+++ b/krr_outputs/raamatupidamise_seadus_peep.json
@@ -286,7 +286,13 @@
         {
           "@id": "http://eurovoc.europa.eu/5211"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32009L0049"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_RAAMAT",

--- a/krr_outputs/rahapesu_ja_terrorismi_rahastamise_tokestamise_seadus_peep.json
+++ b/krr_outputs/rahapesu_ja_terrorismi_rahastamise_tokestamise_seadus_peep.json
@@ -79,7 +79,13 @@
         {
           "@id": "http://eurovoc.europa.eu/0816"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32009L0110"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_RTRT",

--- a/krr_outputs/rahvatervise_seadus_peep.json
+++ b/krr_outputs/rahvatervise_seadus_peep.json
@@ -70,7 +70,13 @@
         {
           "@id": "http://eurovoc.europa.eu/5211"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32013L0051"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_RTerS",

--- a/krr_outputs/rahvusvahelise_eraoiguse_seadus_peep.json
+++ b/krr_outputs/rahvusvahelise_eraoiguse_seadus_peep.json
@@ -46,7 +46,13 @@
         {
           "@id": "http://eurovoc.europa.eu/5226"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32008L0048"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_REÕS",

--- a/krr_outputs/rakenduskorgkooli_seadus_peep.json
+++ b/krr_outputs/rakenduskorgkooli_seadus_peep.json
@@ -52,7 +52,13 @@
         {
           "@id": "http://eurovoc.europa.eu/5211"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32005L0036"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_RakKKS",

--- a/krr_outputs/raudteeseadus_peep.json
+++ b/krr_outputs/raudteeseadus_peep.json
@@ -60,7 +60,40 @@
         {
           "@id": "http://eurovoc.europa.eu/3611"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32004L0049"
+        },
+        {
+          "@id": "estleg:EU_32008L0057"
+        },
+        {
+          "@id": "estleg:EU_32010L0061"
+        },
+        {
+          "@id": "estleg:EU_32005L0047"
+        },
+        {
+          "@id": "estleg:EU_32007L0059"
+        },
+        {
+          "@id": "estleg:EU_32009L0018"
+        },
+        {
+          "@id": "estleg:EU_32008L0068"
+        },
+        {
+          "@id": "estleg:EU_32007L0058"
+        },
+        {
+          "@id": "estleg:EU_32008L0110"
+        },
+        {
+          "@id": "estleg:EU_32009L0149"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_RAUDTEE",

--- a/krr_outputs/ravimiseadus_peep.json
+++ b/krr_outputs/ravimiseadus_peep.json
@@ -74,7 +74,13 @@
         {
           "@id": "http://eurovoc.europa.eu/2811"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32005L0036"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_RavS",

--- a/krr_outputs/reklaamiseadus_peep.json
+++ b/krr_outputs/reklaamiseadus_peep.json
@@ -58,7 +58,13 @@
         {
           "@id": "http://eurovoc.europa.eu/5631"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32008L0048"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_REKLAA",

--- a/krr_outputs/relvaseadus_peep.json
+++ b/krr_outputs/relvaseadus_peep.json
@@ -73,7 +73,13 @@
         {
           "@id": "http://eurovoc.europa.eu/5226"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32008L0051"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_RelvS",

--- a/krr_outputs/riigi_teataja_seadus_peep.json
+++ b/krr_outputs/riigi_teataja_seadus_peep.json
@@ -52,7 +52,13 @@
         {
           "@id": "http://eurovoc.europa.eu/2811"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32009L0071"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_RIIGI",

--- a/krr_outputs/riigihangete_seadus_peep.json
+++ b/krr_outputs/riigihangete_seadus_peep.json
@@ -103,7 +103,22 @@
         {
           "@id": "http://eurovoc.europa.eu/2421"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32009L0028"
+        },
+        {
+          "@id": "estleg:EU_32009L0033"
+        },
+        {
+          "@id": "estleg:EU_32007L0066"
+        },
+        {
+          "@id": "estleg:EU_32009L0081"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_RIIGIH",

--- a/krr_outputs/riigiloivuseadus_peep.json
+++ b/krr_outputs/riigiloivuseadus_peep.json
@@ -214,7 +214,19 @@
         {
           "@id": "http://eurovoc.europa.eu/0411"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32004L0049"
+        },
+        {
+          "@id": "estleg:EU_32009L0028"
+        },
+        {
+          "@id": "estleg:EU_32003L0098"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_RIIGIL_2",

--- a/krr_outputs/riigivastutuse_seadus_peep.json
+++ b/krr_outputs/riigivastutuse_seadus_peep.json
@@ -36,7 +36,13 @@
         {
           "@id": "http://eurovoc.europa.eu/2446"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32009L0052"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_RVastS",

--- a/krr_outputs/riikliku_pensionikindlustuse_seadus_peep.json
+++ b/krr_outputs/riikliku_pensionikindlustuse_seadus_peep.json
@@ -163,7 +163,13 @@
         {
           "@id": "http://eurovoc.europa.eu/5211"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32010L0041"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_RPKS",

--- a/krr_outputs/ruumiandmete_seadus_peep.json
+++ b/krr_outputs/ruumiandmete_seadus_peep.json
@@ -232,7 +232,13 @@
         {
           "@id": "http://eurovoc.europa.eu/2446"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32007L0002"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_RAS",

--- a/krr_outputs/saastuse_kompleksse_valtimise_ja_kontrollimise_seadus_peep.json
+++ b/krr_outputs/saastuse_kompleksse_valtimise_ja_kontrollimise_seadus_peep.json
@@ -46,7 +46,16 @@
         {
           "@id": "http://eurovoc.europa.eu/2446"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32008L0001"
+        },
+        {
+          "@id": "estleg:EU_32009L0031"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_SVKS",

--- a/krr_outputs/sadamaseadus_peep.json
+++ b/krr_outputs/sadamaseadus_peep.json
@@ -41,7 +41,25 @@
         {
           "@id": "http://eurovoc.europa.eu/1221"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32007L0071"
+        },
+        {
+          "@id": "estleg:EU_32005L0065"
+        },
+        {
+          "@id": "estleg:EU_32009L0016"
+        },
+        {
+          "@id": "estleg:EU_32000L0059"
+        },
+        {
+          "@id": "estleg:EU_31995L0021"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_Sadamaseadus",

--- a/krr_outputs/soolise_vordoiguslikkuse_seadus_peep.json
+++ b/krr_outputs/soolise_vordoiguslikkuse_seadus_peep.json
@@ -58,7 +58,19 @@
         {
           "@id": "http://eurovoc.europa.eu/2431"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32004L0113"
+        },
+        {
+          "@id": "estleg:EU_32006L0054"
+        },
+        {
+          "@id": "estleg:EU_32002L0073"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_SoVS",

--- a/krr_outputs/strateegilise_kauba_seadus_peep.json
+++ b/krr_outputs/strateegilise_kauba_seadus_peep.json
@@ -49,7 +49,16 @@
         {
           "@id": "http://eurovoc.europa.eu/2446"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32010L0080"
+        },
+        {
+          "@id": "estleg:EU_32009L0043"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_STRATE",

--- a/krr_outputs/tagatisfondi_seadus_peep.json
+++ b/krr_outputs/tagatisfondi_seadus_peep.json
@@ -46,7 +46,13 @@
         {
           "@id": "http://eurovoc.europa.eu/5246"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32009L0014"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_TFS",

--- a/krr_outputs/taimede_paljundamise_ja_sordikaitse_seadus_peep.json
+++ b/krr_outputs/taimede_paljundamise_ja_sordikaitse_seadus_peep.json
@@ -88,7 +88,22 @@
         {
           "@id": "http://eurovoc.europa.eu/3606"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32009L0145"
+        },
+        {
+          "@id": "estleg:EU_32010L0060"
+        },
+        {
+          "@id": "estleg:EU_32008L0062"
+        },
+        {
+          "@id": "estleg:EU_32008L0090"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_TPSKS",

--- a/krr_outputs/taimekaitseseadus_peep.json
+++ b/krr_outputs/taimekaitseseadus_peep.json
@@ -73,7 +73,16 @@
         {
           "@id": "http://eurovoc.europa.eu/3606"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32009L0128"
+        },
+        {
+          "@id": "estleg:EU_32009L0143"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_TaimKS",

--- a/krr_outputs/tarbijakaitseseadus_peep.json
+++ b/krr_outputs/tarbijakaitseseadus_peep.json
@@ -50,7 +50,22 @@
         {
           "@id": "http://eurovoc.europa.eu/2416"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32008L0048"
+        },
+        {
+          "@id": "estleg:EU_32009L0028"
+        },
+        {
+          "@id": "estleg:EU_32009L0073"
+        },
+        {
+          "@id": "estleg:EU_32005L0029"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_TarbKS",

--- a/krr_outputs/teeseadus_peep.json
+++ b/krr_outputs/teeseadus_peep.json
@@ -199,7 +199,16 @@
         {
           "@id": "http://eurovoc.europa.eu/1221"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32007L0002"
+        },
+        {
+          "@id": "estleg:EU_32008L0096"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_TeeS",

--- a/krr_outputs/tervishoiuteenuste_korraldamise_seadus_peep.json
+++ b/krr_outputs/tervishoiuteenuste_korraldamise_seadus_peep.json
@@ -178,7 +178,13 @@
         {
           "@id": "http://eurovoc.europa.eu/2441"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32005L0036"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_TTKS",

--- a/krr_outputs/toolepinguseadus_peep.json
+++ b/krr_outputs/toolepinguseadus_peep.json
@@ -79,7 +79,22 @@
         {
           "@id": "http://eurovoc.europa.eu/5611"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32009L0052"
+        },
+        {
+          "@id": "estleg:EU_31996L0034"
+        },
+        {
+          "@id": "estleg:EU_32007L0059"
+        },
+        {
+          "@id": "estleg:EU_32002L0073"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_toolepinguseadus",

--- a/krr_outputs/toostusheite_seadus_peep.json
+++ b/krr_outputs/toostusheite_seadus_peep.json
@@ -44,7 +44,13 @@
         {
           "@id": "http://eurovoc.europa.eu/2441"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32010L0075"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_THS",

--- a/krr_outputs/tootajate_uleuhenduselise_kaasamise_seadus_peep.json
+++ b/krr_outputs/tootajate_uleuhenduselise_kaasamise_seadus_peep.json
@@ -46,7 +46,13 @@
         {
           "@id": "http://eurovoc.europa.eu/2441"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32009L0038"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_TUK",

--- a/krr_outputs/toote_nouetele_vastavuse_seadus_peep.json
+++ b/krr_outputs/toote_nouetele_vastavuse_seadus_peep.json
@@ -70,7 +70,25 @@
         {
           "@id": "http://eurovoc.europa.eu/2806"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32009L0125"
+        },
+        {
+          "@id": "estleg:EU_32009L0048"
+        },
+        {
+          "@id": "estleg:EU_32008L0013"
+        },
+        {
+          "@id": "estleg:EU_32010L0030"
+        },
+        {
+          "@id": "estleg:EU_32008L0057"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_TNV",

--- a/krr_outputs/transposition_mapping.json
+++ b/krr_outputs/transposition_mapping.json
@@ -2,20 +2,3122 @@
   "generated": "2026-05-11",
   "source": "https://publications.europa.eu/webapi/rdf/sparql",
   "country": "EST",
-  "documented_empty": true,
-  "documented_empty_reason": "EUR-Lex returned zero Estonian transposition measures; recorded as an intentional empty snapshot via --allow-empty.",
-  "partial": true,
-  "total_measures_fetched": 0,
-  "total_matched": 0,
-  "total_unmatched": 0,
+  "documented_empty": false,
+  "partial": false,
+  "total_measures_fetched": 720,
+  "total_matched": 295,
+  "total_unmatched": 406,
   "total_skipped_missing_directives": 0,
   "total_skipped_missing_law_iris": 0,
-  "unique_directives": 0,
-  "unique_laws": 0,
-  "law_files_updated": 0,
-  "directive_nodes_updated": 0,
-  "mappings": [],
-  "unmatched_sample": [],
+  "unique_directives": 205,
+  "unique_laws": 99,
+  "law_files_updated": 121,
+  "directive_nodes_updated": 205,
+  "directive_deadlines_fetched": 3418,
+  "directive_deadline_nodes_updated": 2616,
+  "mappings": [
+    {
+      "directive_celex": "31990L0314",
+      "directive_iri": "estleg:EU_31990L0314",
+      "national_title": "Võlaõigusseadus",
+      "matched_law_name": "volaigusseadus",
+      "matched_source_act": "Võlaõigusseadus",
+      "law_files": [
+        "volaigusseadus_osa11_peep.json",
+        "volaigusseadus_osa12_peep.json",
+        "volaigusseadus_osa13_peep.json",
+        "volaigusseadus_osa1_peep.json",
+        "volaigusseadus_osa3_peep.json",
+        "volaigusseadus_osa4_peep.json",
+        "volaigusseadus_osa5_peep.json",
+        "volaigusseadus_osa7_peep.json",
+        "volaigusseadus_osa8_peep.json",
+        "volaigusseadus_osa9_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "31992L0043",
+      "directive_iri": "estleg:EU_31992L0043",
+      "national_title": "LOODUSKAITSESEADUS1",
+      "matched_law_name": "looduskaitseseadus",
+      "matched_source_act": "Looduskaitseseadus",
+      "law_files": [
+        "looduskaitseseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "31993L0013",
+      "directive_iri": "estleg:EU_31993L0013",
+      "national_title": "VÕLAÕIGUSSEADUS",
+      "matched_law_name": "volaigusseadus",
+      "matched_source_act": "Võlaõigusseadus",
+      "law_files": [
+        "volaigusseadus_osa11_peep.json",
+        "volaigusseadus_osa12_peep.json",
+        "volaigusseadus_osa13_peep.json",
+        "volaigusseadus_osa1_peep.json",
+        "volaigusseadus_osa3_peep.json",
+        "volaigusseadus_osa4_peep.json",
+        "volaigusseadus_osa5_peep.json",
+        "volaigusseadus_osa7_peep.json",
+        "volaigusseadus_osa8_peep.json",
+        "volaigusseadus_osa9_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "31995L0021",
+      "directive_iri": "estleg:EU_31995L0021",
+      "national_title": "SADAMASEADUS1",
+      "matched_law_name": "sadamaseadus",
+      "matched_source_act": "Sadamaseadus",
+      "law_files": [
+        "sadamaseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "31996L0034",
+      "directive_iri": "estleg:EU_31996L0034",
+      "national_title": "TÖÖLEPINGU SEADUS",
+      "matched_law_name": "toolepinguseadus",
+      "matched_source_act": "Töölepingu seadus",
+      "law_files": [
+        "toolepinguseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "31996L0071",
+      "directive_iri": "estleg:EU_31996L0071",
+      "national_title": "EESTISSE LÄHETATUD TÖÖTAJATE TÖÖTINGIMUSTE SEADUS 1",
+      "matched_law_name": "eestisse_lahetatud_tootajate_tootingimuste_seadus",
+      "matched_source_act": "Eestisse lähetatud töötajate töötingimuste seadus",
+      "law_files": [
+        "eestisse_lahetatud_tootajate_tootingimuste_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "31997L0007",
+      "directive_iri": "estleg:EU_31997L0007",
+      "national_title": "Võlaõigusseadus",
+      "matched_law_name": "volaigusseadus",
+      "matched_source_act": "Võlaõigusseadus",
+      "law_files": [
+        "volaigusseadus_osa11_peep.json",
+        "volaigusseadus_osa12_peep.json",
+        "volaigusseadus_osa13_peep.json",
+        "volaigusseadus_osa1_peep.json",
+        "volaigusseadus_osa3_peep.json",
+        "volaigusseadus_osa4_peep.json",
+        "volaigusseadus_osa5_peep.json",
+        "volaigusseadus_osa7_peep.json",
+        "volaigusseadus_osa8_peep.json",
+        "volaigusseadus_osa9_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "31999L0031",
+      "directive_iri": "estleg:EU_31999L0031",
+      "national_title": "JÄÄTMESEADUS",
+      "matched_law_name": "jaatmeseadus",
+      "matched_source_act": "Jäätmeseadus",
+      "law_files": [
+        "jaatmeseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "31999L0044",
+      "directive_iri": "estleg:EU_31999L0044",
+      "national_title": "Võlaõigusseadus",
+      "matched_law_name": "volaigusseadus",
+      "matched_source_act": "Võlaõigusseadus",
+      "law_files": [
+        "volaigusseadus_osa11_peep.json",
+        "volaigusseadus_osa12_peep.json",
+        "volaigusseadus_osa13_peep.json",
+        "volaigusseadus_osa1_peep.json",
+        "volaigusseadus_osa3_peep.json",
+        "volaigusseadus_osa4_peep.json",
+        "volaigusseadus_osa5_peep.json",
+        "volaigusseadus_osa7_peep.json",
+        "volaigusseadus_osa8_peep.json",
+        "volaigusseadus_osa9_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32000L0059",
+      "directive_iri": "estleg:EU_32000L0059",
+      "national_title": "SADAMASEADUS1",
+      "matched_law_name": "sadamaseadus",
+      "matched_source_act": "Sadamaseadus",
+      "law_files": [
+        "sadamaseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32000L0060",
+      "directive_iri": "estleg:EU_32000L0060",
+      "national_title": "VEESEADUS",
+      "matched_law_name": "veeseadus",
+      "matched_source_act": "Veeseadus",
+      "law_files": [
+        "veeseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32000L0060",
+      "directive_iri": "estleg:EU_32000L0060",
+      "national_title": "KESKKONNAVASTUTUSE SEADUS1",
+      "matched_law_name": "keskkonnavastutuse_seadus",
+      "matched_source_act": "Keskkonnavastutuse seadus",
+      "law_files": [
+        "keskkonnavastutuse_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32001L0042",
+      "directive_iri": "estleg:EU_32001L0042",
+      "national_title": "Keskkonnamõju hindamise ja keskkonnajuhtimissüsteemi seaduse muutmise seadus",
+      "matched_law_name": "keskkonnamoju_hindamise_ja_keskkonnajuhtimissusteemi_seadus",
+      "matched_source_act": "Keskkonnamõju hindamise ja keskkonnajuhtimissüsteemi seadus",
+      "law_files": [
+        "keskkonnamoju_hindamise_ja_keskkonnajuhtimissusteemi_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32002L0015",
+      "directive_iri": "estleg:EU_32002L0015",
+      "national_title": "LIIKLUSSEADUSE MUUTMISE SEADUS",
+      "matched_law_name": "liiklusseadus",
+      "matched_source_act": "Liiklusseadus",
+      "law_files": [
+        "liiklusseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32002L0065",
+      "directive_iri": "estleg:EU_32002L0065",
+      "national_title": "Võlaõigusseadus",
+      "matched_law_name": "volaigusseadus",
+      "matched_source_act": "Võlaõigusseadus",
+      "law_files": [
+        "volaigusseadus_osa11_peep.json",
+        "volaigusseadus_osa12_peep.json",
+        "volaigusseadus_osa13_peep.json",
+        "volaigusseadus_osa1_peep.json",
+        "volaigusseadus_osa3_peep.json",
+        "volaigusseadus_osa4_peep.json",
+        "volaigusseadus_osa5_peep.json",
+        "volaigusseadus_osa7_peep.json",
+        "volaigusseadus_osa8_peep.json",
+        "volaigusseadus_osa9_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32002L0073",
+      "directive_iri": "estleg:EU_32002L0073",
+      "national_title": "VÕRDSE KOHTLEMISE SEADUS1",
+      "matched_law_name": "vordse_kohtlemise_seadus",
+      "matched_source_act": "Võrdse kohtlemise seadus",
+      "law_files": [
+        "vordse_kohtlemise_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32002L0073",
+      "directive_iri": "estleg:EU_32002L0073",
+      "national_title": "SOOLISE VÕRDÕIGUSLIKKUSE SEADUS1",
+      "matched_law_name": "soolise_vordoiguslikkuse_seadus",
+      "matched_source_act": "Soolise võrdõiguslikkuse seadus",
+      "law_files": [
+        "soolise_vordoiguslikkuse_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32002L0073",
+      "directive_iri": "estleg:EU_32002L0073",
+      "national_title": "TÖÖLEPINGU SEADUS",
+      "matched_law_name": "toolepinguseadus",
+      "matched_source_act": "Töölepingu seadus",
+      "law_files": [
+        "toolepinguseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32002L0096",
+      "directive_iri": "estleg:EU_32002L0096",
+      "national_title": "JÄÄTMESEADUS",
+      "matched_law_name": "jaatmeseadus",
+      "matched_source_act": "Jäätmeseadus",
+      "law_files": [
+        "jaatmeseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32003L0033",
+      "directive_iri": "estleg:EU_32003L0033",
+      "national_title": "TUBAKASEADUS",
+      "matched_law_name": "tubaka_seadus",
+      "matched_source_act": "Tubakaseadus",
+      "law_files": [
+        "tubaka_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32003L0035",
+      "directive_iri": "estleg:EU_32003L0035",
+      "national_title": "Jäätmeseadus",
+      "matched_law_name": "jaatmeseadus",
+      "matched_source_act": "Jäätmeseadus",
+      "law_files": [
+        "jaatmeseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32003L0098",
+      "directive_iri": "estleg:EU_32003L0098",
+      "national_title": "Halduskoostöö seadus",
+      "matched_law_name": "halduskoostoo_seadus",
+      "matched_source_act": "Halduskoostöö seadus",
+      "law_files": [
+        "halduskoostoo_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32003L0098",
+      "directive_iri": "estleg:EU_32003L0098",
+      "national_title": "Haldusmenetluse seadus",
+      "matched_law_name": "haldusmenetluse",
+      "matched_source_act": "Haldusmenetluse seadus",
+      "law_files": [
+        "haldusmenetluse_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32003L0098",
+      "directive_iri": "estleg:EU_32003L0098",
+      "national_title": "Isikuandmete kaitse seadus1",
+      "matched_law_name": "isikuandmete_kaitse_seadus",
+      "matched_source_act": "Isikuandmete kaitse seadus",
+      "law_files": [
+        "isikuandmete_kaitse_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32003L0098",
+      "directive_iri": "estleg:EU_32003L0098",
+      "national_title": "Riigilõivuseadus",
+      "matched_law_name": "riigiloivuseadus",
+      "matched_source_act": "Riigilõivuseadus",
+      "law_files": [
+        "riigiloivuseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32003L0098",
+      "directive_iri": "estleg:EU_32003L0098",
+      "national_title": "Avaliku teabe seadus",
+      "matched_law_name": "avaliku_teabe_seadus",
+      "matched_source_act": "Avaliku teabe seadus",
+      "law_files": [
+        "avaliku_teabe_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32003L0110",
+      "directive_iri": "estleg:EU_32003L0110",
+      "national_title": "Väljasõidukohustuse ja sissesõidukeelu seadus",
+      "matched_law_name": "valjasoidukohustuse_ja_sissesoidukeelu_seadus",
+      "matched_source_act": "Väljasõidukohustuse ja sissesõidukeelu seadus",
+      "law_files": [
+        "valjasoidukohustuse_ja_sissesoidukeelu_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32004L0049",
+      "directive_iri": "estleg:EU_32004L0049",
+      "national_title": "Raudteeseadus1",
+      "matched_law_name": "raudteeseadus",
+      "matched_source_act": "Raudteeseadus",
+      "law_files": [
+        "raudteeseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32004L0049",
+      "directive_iri": "estleg:EU_32004L0049",
+      "national_title": "Haldusmenetluse seadus",
+      "matched_law_name": "haldusmenetluse",
+      "matched_source_act": "Haldusmenetluse seadus",
+      "law_files": [
+        "haldusmenetluse_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32004L0049",
+      "directive_iri": "estleg:EU_32004L0049",
+      "national_title": "Raudteeseaduse ja riigilõivuseaduse muutmise seadus",
+      "matched_law_name": "riigiloivuseadus",
+      "matched_source_act": "Riigilõivuseadus",
+      "law_files": [
+        "riigiloivuseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32004L0049",
+      "directive_iri": "estleg:EU_32004L0049",
+      "national_title": "Lennundusseaduse, meresõiduohutuse seaduse ja raudteeseaduse muutmise seadus",
+      "matched_law_name": "meresoiduohutuse_seadus",
+      "matched_source_act": "Meresõiduohutuse seadus",
+      "law_files": [
+        "meresoiduohutuse_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32004L0049",
+      "directive_iri": "estleg:EU_32004L0049",
+      "national_title": "Halduskohtumenetluse seadustik",
+      "matched_law_name": "halduskohtumenetluse_seadustik",
+      "matched_source_act": "Halduskohtumenetluse seadustik",
+      "law_files": [
+        "halduskohtumenetluse_seadustik_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32004L0049",
+      "directive_iri": "estleg:EU_32004L0049",
+      "national_title": "Vabariigi Valitsuse seadus",
+      "matched_law_name": "vabariigi_valitsuse_seadus",
+      "matched_source_act": "Vabariigi Valitsuse seadus",
+      "law_files": [
+        "vabariigi_valitsuse_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32004L0113",
+      "directive_iri": "estleg:EU_32004L0113",
+      "national_title": "VÕRDSE KOHTLEMISE SEADUS1",
+      "matched_law_name": "vordse_kohtlemise_seadus",
+      "matched_source_act": "Võrdse kohtlemise seadus",
+      "law_files": [
+        "vordse_kohtlemise_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32004L0113",
+      "directive_iri": "estleg:EU_32004L0113",
+      "national_title": "SOOLISE VÕRDÕIGUSLIKKUSE SEADUS1",
+      "matched_law_name": "soolise_vordoiguslikkuse_seadus",
+      "matched_source_act": "Soolise võrdõiguslikkuse seadus",
+      "law_files": [
+        "soolise_vordoiguslikkuse_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32005L0029",
+      "directive_iri": "estleg:EU_32005L0029",
+      "national_title": "TARBIJAKAITSESEADUSE JA VÕLAÕIGUSSEADUSE MUUTMISE SEADUS",
+      "matched_law_name": "tarbijakaitseseadus",
+      "matched_source_act": "Tarbijakaitseseadus",
+      "law_files": [
+        "tarbijakaitseseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32005L0036",
+      "directive_iri": "estleg:EU_32005L0036",
+      "national_title": "PLANEERIMISSEADUS",
+      "matched_law_name": "planeerimisseadus",
+      "matched_source_act": "Planeerimisseadus",
+      "law_files": [
+        "planeerimisseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32005L0036",
+      "directive_iri": "estleg:EU_32005L0036",
+      "national_title": "VETERINAARKORRALDUSE SEADUS1",
+      "matched_law_name": "veterinaarkorralduse_seadus",
+      "matched_source_act": "Veterinaarkorralduse seadus",
+      "law_files": [
+        "veterinaarkorralduse_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32005L0036",
+      "directive_iri": "estleg:EU_32005L0036",
+      "national_title": "EESTI VABARIIGI HARIDUSSEADUS",
+      "matched_law_name": "eesti_vabariigi_haridusseadus",
+      "matched_source_act": "Eesti Vabariigi haridusseadus",
+      "law_files": [
+        "eesti_vabariigi_haridusseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32005L0036",
+      "directive_iri": "estleg:EU_32005L0036",
+      "national_title": "RAKENDUSKÕRGKOOLI SEADUS",
+      "matched_law_name": "rakenduskorgkooli_seadus",
+      "matched_source_act": "Rakenduskõrgkooli seadus",
+      "law_files": [
+        "rakenduskorgkooli_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32005L0036",
+      "directive_iri": "estleg:EU_32005L0036",
+      "national_title": "RAVIMISEADUS",
+      "matched_law_name": "ravimiseadus",
+      "matched_source_act": "Ravimiseadus",
+      "law_files": [
+        "ravimiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32005L0036",
+      "directive_iri": "estleg:EU_32005L0036",
+      "national_title": "TERVISHOIUTEENUSTE KORRALDAMISE SEADUS",
+      "matched_law_name": "tervishoiuteenuste_korraldamise_seadus",
+      "matched_source_act": "Tervishoiuteenuste korraldamise seadus",
+      "law_files": [
+        "tervishoiuteenuste_korraldamise_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32005L0036",
+      "directive_iri": "estleg:EU_32005L0036",
+      "national_title": "ÜLIKOOLISEADUS",
+      "matched_law_name": "ulikooliseadus",
+      "matched_source_act": "Ülikooliseadus",
+      "law_files": [
+        "ulikooliseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32005L0047",
+      "directive_iri": "estleg:EU_32005L0047",
+      "national_title": "Raudteeseadus1",
+      "matched_law_name": "raudteeseadus",
+      "matched_source_act": "Raudteeseadus",
+      "law_files": [
+        "raudteeseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32005L0065",
+      "directive_iri": "estleg:EU_32005L0065",
+      "national_title": "SADAMASEADUS1",
+      "matched_law_name": "sadamaseadus",
+      "matched_source_act": "Sadamaseadus",
+      "law_files": [
+        "sadamaseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32006L0021",
+      "directive_iri": "estleg:EU_32006L0021",
+      "national_title": "Maapõueseadus",
+      "matched_law_name": "maapoueseadus",
+      "matched_source_act": "Maapõueseadus",
+      "law_files": [
+        "maapoueseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32006L0021",
+      "directive_iri": "estleg:EU_32006L0021",
+      "national_title": "JÄÄTMESEADUS",
+      "matched_law_name": "jaatmeseadus",
+      "matched_source_act": "Jäätmeseadus",
+      "law_files": [
+        "jaatmeseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32006L0043",
+      "directive_iri": "estleg:EU_32006L0043",
+      "national_title": "AUDIITORTEGEVUSE SEADUS1",
+      "matched_law_name": "audiitortegevuse_seadus",
+      "matched_source_act": "Audiitortegevuse seadus",
+      "law_files": [
+        "audiitortegevuse_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32006L0050",
+      "directive_iri": "estleg:EU_32006L0050",
+      "national_title": "BIOTSIIDISEADUS1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32006L0054",
+      "directive_iri": "estleg:EU_32006L0054",
+      "national_title": "VÕRDSE KOHTLEMISE SEADUS1",
+      "matched_law_name": "vordse_kohtlemise_seadus",
+      "matched_source_act": "Võrdse kohtlemise seadus",
+      "law_files": [
+        "vordse_kohtlemise_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32006L0054",
+      "directive_iri": "estleg:EU_32006L0054",
+      "national_title": "SOOLISE VÕRDÕIGUSLIKKUSE SEADUS1",
+      "matched_law_name": "soolise_vordoiguslikkuse_seadus",
+      "matched_source_act": "Soolise võrdõiguslikkuse seadus",
+      "law_files": [
+        "soolise_vordoiguslikkuse_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32006L0117",
+      "directive_iri": "estleg:EU_32006L0117",
+      "national_title": "KIIRGUSSEADUS1",
+      "matched_law_name": "kiirgusseadus",
+      "matched_source_act": "Kiirgusseadus",
+      "law_files": [
+        "kiirgusseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32006L0123",
+      "directive_iri": "estleg:EU_32006L0123",
+      "national_title": "EUROOPA LIIDU TEENUSTE DIREKTIIVI RAKENDAMISE SEADUS1",
+      "matched_law_name": "euroopa_liidu_teenuste_direktiivi_rakendamise_seadus",
+      "matched_source_act": "Euroopa Liidu teenuste direktiivi rakendamise seadus",
+      "law_files": [
+        "euroopa_liidu_teenuste_direktiivi_rakendamise_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32006L0126",
+      "directive_iri": "estleg:EU_32006L0126",
+      "national_title": "Liiklusseadus1",
+      "matched_law_name": "liiklusseadus",
+      "matched_source_act": "Liiklusseadus",
+      "law_files": [
+        "liiklusseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32006L0140",
+      "directive_iri": "estleg:EU_32006L0140",
+      "national_title": "BIOTSIIDISEADUS1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32007L0002",
+      "directive_iri": "estleg:EU_32007L0002",
+      "national_title": "TEESEADUS1",
+      "matched_law_name": "teeseadus",
+      "matched_source_act": "Teeseadus",
+      "law_files": [
+        "teeseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32007L0002",
+      "directive_iri": "estleg:EU_32007L0002",
+      "national_title": "KOHANIMESEADUS",
+      "matched_law_name": "nimeseadus",
+      "matched_source_act": "Nimeseadus",
+      "law_files": [
+        "nimeseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32007L0002",
+      "directive_iri": "estleg:EU_32007L0002",
+      "national_title": "MAAKATASTRISEADUS",
+      "matched_law_name": "maakatastriseadus",
+      "matched_source_act": "Maakatastriseadus",
+      "law_files": [
+        "maakatastriseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32007L0002",
+      "directive_iri": "estleg:EU_32007L0002",
+      "national_title": "KESKKONNAREGISTRI SEADUS",
+      "matched_law_name": "keskkonnaregistri_seadus",
+      "matched_source_act": "Keskkonnaregistri seadus",
+      "law_files": [
+        "keskkonnaregistri_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32007L0002",
+      "directive_iri": "estleg:EU_32007L0002",
+      "national_title": "Ruumiandmete seadus1",
+      "matched_law_name": "ruumiandmete_seadus",
+      "matched_source_act": "Ruumiandmete seadus",
+      "law_files": [
+        "ruumiandmete_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32007L0002",
+      "directive_iri": "estleg:EU_32007L0002",
+      "national_title": "AVALIKU TEABE SEADUS",
+      "matched_law_name": "avaliku_teabe_seadus",
+      "matched_source_act": "Avaliku teabe seadus",
+      "law_files": [
+        "avaliku_teabe_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32007L0002",
+      "directive_iri": "estleg:EU_32007L0002",
+      "national_title": "EESTI TERRITOORIUMI HALDUSJAOTUSE SEADUS",
+      "matched_law_name": "eesti_territooriumi_haldusjaotuse_seadus",
+      "matched_source_act": "Eesti territooriumi haldusjaotuse seadus",
+      "law_files": [
+        "eesti_territooriumi_haldusjaotuse_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32007L0020",
+      "directive_iri": "estleg:EU_32007L0020",
+      "national_title": "BIOTSIIDISEADUS1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32007L0023",
+      "directive_iri": "estleg:EU_32007L0023",
+      "national_title": "LÕHKEMATERJALISEADUS1",
+      "matched_law_name": "lohkematerjaliseadus",
+      "matched_source_act": "Lõhkematerjaliseadus",
+      "law_files": [
+        "lohkematerjaliseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32007L0036",
+      "directive_iri": "estleg:EU_32007L0036",
+      "national_title": "TSIVIILSEADUSTIKU ÜLDOSA SEADUS",
+      "matched_law_name": "tsiviilseadustiku_uldosa_seadus",
+      "matched_source_act": "Tsiviilseadustiku üldosa seadus",
+      "law_files": [
+        "tsiviilseadustiku_uldosa_seadus_osa2_peep.json",
+        "tsiviilseadustiku_uldosa_seadus_osa4_peep.json",
+        "tsiviilseadustiku_uldosa_seadus_osa7_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32007L0036",
+      "directive_iri": "estleg:EU_32007L0036",
+      "national_title": "ÄRISEADUSTIK1",
+      "matched_law_name": "ariseadustik1",
+      "matched_source_act": "Äriseadustik1",
+      "law_files": [
+        "ariseadustik1_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32007L0036",
+      "directive_iri": "estleg:EU_32007L0036",
+      "national_title": "EESTI VÄÄRTPABERITE KESKREGISTRI SEADUS",
+      "matched_law_name": "eesti_vaartpaberite_keskregistri_seadus",
+      "matched_source_act": "Eesti väärtpaberite keskregistri seadus",
+      "law_files": [
+        "eesti_vaartpaberite_keskregistri_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32007L0043",
+      "directive_iri": "estleg:EU_32007L0043",
+      "national_title": "LOOMAKAITSESEADUS1",
+      "matched_law_name": "loomakaitseseadus",
+      "matched_source_act": "Loomakaitseseadus",
+      "law_files": [
+        "loomakaitseseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32007L0044",
+      "directive_iri": "estleg:EU_32007L0044",
+      "national_title": "KINDLUSTUSTEGEVUSE SEADUS1",
+      "matched_law_name": "kindlustustegevuse_seadus",
+      "matched_source_act": "Kindlustustegevuse seadus",
+      "law_files": [
+        "kindlustustegevuse_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32007L0044",
+      "directive_iri": "estleg:EU_32007L0044",
+      "national_title": "VÄÄRTPABERITURU SEADUS1",
+      "matched_law_name": "vaartpaberituru_seadus",
+      "matched_source_act": "Väärtpaberituru seadus",
+      "law_files": [
+        "vaartpaberituru_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32007L0044",
+      "directive_iri": "estleg:EU_32007L0044",
+      "national_title": "INVESTEERIMISFONDIDE SEADUS1",
+      "matched_law_name": "investeerimisfondide_seadus",
+      "matched_source_act": "Investeerimisfondide seadus",
+      "law_files": [
+        "investeerimisfondide_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32007L0047",
+      "directive_iri": "estleg:EU_32007L0047",
+      "national_title": "Meditsiiniseadme seadus1",
+      "matched_law_name": "meditsiiniseadme_seadus",
+      "matched_source_act": "Meditsiiniseadme seadus",
+      "law_files": [
+        "meditsiiniseadme_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32007L0047",
+      "directive_iri": "estleg:EU_32007L0047",
+      "national_title": "BIOTSIIDISEADUS1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32007L0051",
+      "directive_iri": "estleg:EU_32007L0051",
+      "national_title": "Meditsiiniseadme seadus1",
+      "matched_law_name": "meditsiiniseadme_seadus",
+      "matched_source_act": "Meditsiiniseadme seadus",
+      "law_files": [
+        "meditsiiniseadme_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32007L0058",
+      "directive_iri": "estleg:EU_32007L0058",
+      "national_title": "RAUDTEESEADUS1",
+      "matched_law_name": "raudteeseadus",
+      "matched_source_act": "Raudteeseadus",
+      "law_files": [
+        "raudteeseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32007L0059",
+      "directive_iri": "estleg:EU_32007L0059",
+      "national_title": "Raudteeseadus1",
+      "matched_law_name": "raudteeseadus",
+      "matched_source_act": "Raudteeseadus",
+      "law_files": [
+        "raudteeseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32007L0059",
+      "directive_iri": "estleg:EU_32007L0059",
+      "national_title": "Töölepingu seadus",
+      "matched_law_name": "toolepinguseadus",
+      "matched_source_act": "Töölepingu seadus",
+      "law_files": [
+        "toolepinguseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32007L0064",
+      "directive_iri": "estleg:EU_32007L0064",
+      "national_title": "MAKSEASUTUSTE JA E-RAHA ASUTUSTE SEADUS1",
+      "matched_law_name": "makseasutuste_ja_e_raha_asutuste_seadus",
+      "matched_source_act": "Makseasutuste ja e-raha asutuste seadus",
+      "law_files": [
+        "makseasutuste_ja_e_raha_asutuste_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32007L0065",
+      "directive_iri": "estleg:EU_32007L0065",
+      "national_title": "Meediateenuste seadus1",
+      "matched_law_name": "meediateenuste_seadus",
+      "matched_source_act": "Meediateenuste seadus",
+      "law_files": [
+        "meediateenuste_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32007L0066",
+      "directive_iri": "estleg:EU_32007L0066",
+      "national_title": "RIIGIHANGETE SEADUS1",
+      "matched_law_name": "riigihangete_seadus",
+      "matched_source_act": "Riigihangete seadus",
+      "law_files": [
+        "riigihangete_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32007L0069",
+      "directive_iri": "estleg:EU_32007L0069",
+      "national_title": "BIOTSIIDISEADUS1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32007L0070",
+      "directive_iri": "estleg:EU_32007L0070",
+      "national_title": "BIOTSIIDISEADUS1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32007L0071",
+      "directive_iri": "estleg:EU_32007L0071",
+      "national_title": "SADAMASEADUS1",
+      "matched_law_name": "sadamaseadus",
+      "matched_source_act": "Sadamaseadus",
+      "law_files": [
+        "sadamaseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32008L0001",
+      "directive_iri": "estleg:EU_32008L0001",
+      "national_title": "Halduskohtumenetluse seadustik",
+      "matched_law_name": "halduskohtumenetluse_seadustik",
+      "matched_source_act": "Halduskohtumenetluse seadustik",
+      "law_files": [
+        "halduskohtumenetluse_seadustik_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32008L0001",
+      "directive_iri": "estleg:EU_32008L0001",
+      "national_title": "Saastuse kompleksse vältimise ja kontrollimise seadus",
+      "matched_law_name": "saastuse_kompleksse_valtimise_ja_kontrollimise_seadus",
+      "matched_source_act": "Saastuse kompleksse vältimise ja kontrollimise seadus",
+      "law_files": [
+        "saastuse_kompleksse_valtimise_ja_kontrollimise_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32008L0008",
+      "directive_iri": "estleg:EU_32008L0008",
+      "national_title": "KÄIBEMAKSUSEADUS1",
+      "matched_law_name": "kaibemaksuseadus",
+      "matched_source_act": "Käibemaksuseadus",
+      "law_files": [
+        "kaibemaksuseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32008L0009",
+      "directive_iri": "estleg:EU_32008L0009",
+      "national_title": "KÄIBEMAKSUSEADUS1",
+      "matched_law_name": "kaibemaksuseadus",
+      "matched_source_act": "Käibemaksuseadus",
+      "law_files": [
+        "kaibemaksuseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32008L0013",
+      "directive_iri": "estleg:EU_32008L0013",
+      "national_title": "Toote nõuetele vastavuse seadus",
+      "matched_law_name": "toote_nouetele_vastavuse_seadus",
+      "matched_source_act": "Toote nõuetele vastavuse seadus",
+      "law_files": [
+        "toote_nouetele_vastavuse_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32008L0015",
+      "directive_iri": "estleg:EU_32008L0015",
+      "national_title": "BIOTSIIDISEADUS1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32008L0016",
+      "directive_iri": "estleg:EU_32008L0016",
+      "national_title": "BIOTSIIDISEADUS1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32008L0048",
+      "directive_iri": "estleg:EU_32008L0048",
+      "national_title": "VÕLAÕIGUSSEADUSE, TSIVIILSEADUSTIKU ÜLDOSA  SEADUSE JA RAHVUSVAHELISE ERAÕIGUSE SEADUSE RAKENDAMISE SEADUS",
+      "matched_law_name": "rahvusvahelise_eraoiguse_seadus",
+      "matched_source_act": "Rahvusvahelise eraõiguse seadus",
+      "law_files": [
+        "rahvusvahelise_eraoiguse_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32008L0048",
+      "directive_iri": "estleg:EU_32008L0048",
+      "national_title": "TARBIJAKAITSESEADUS",
+      "matched_law_name": "tarbijakaitseseadus",
+      "matched_source_act": "Tarbijakaitseseadus",
+      "law_files": [
+        "tarbijakaitseseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32008L0048",
+      "directive_iri": "estleg:EU_32008L0048",
+      "national_title": "VÕLAÕIGUSSEADUS",
+      "matched_law_name": "volaigusseadus",
+      "matched_source_act": "Võlaõigusseadus",
+      "law_files": [
+        "volaigusseadus_osa11_peep.json",
+        "volaigusseadus_osa12_peep.json",
+        "volaigusseadus_osa13_peep.json",
+        "volaigusseadus_osa1_peep.json",
+        "volaigusseadus_osa3_peep.json",
+        "volaigusseadus_osa4_peep.json",
+        "volaigusseadus_osa5_peep.json",
+        "volaigusseadus_osa7_peep.json",
+        "volaigusseadus_osa8_peep.json",
+        "volaigusseadus_osa9_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32008L0048",
+      "directive_iri": "estleg:EU_32008L0048",
+      "national_title": "ISIKUANDMETE KAITSE SEADUS1",
+      "matched_law_name": "isikuandmete_kaitse_seadus",
+      "matched_source_act": "Isikuandmete kaitse seadus",
+      "law_files": [
+        "isikuandmete_kaitse_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32008L0048",
+      "directive_iri": "estleg:EU_32008L0048",
+      "national_title": "REKLAAMISEADUS",
+      "matched_law_name": "reklaamiseadus",
+      "matched_source_act": "Reklaamiseadus",
+      "law_files": [
+        "reklaamiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32008L0050",
+      "directive_iri": "estleg:EU_32008L0050",
+      "national_title": "Välisõhu kaitse seadus",
+      "matched_law_name": "valisohu_kaitse_seadus",
+      "matched_source_act": "Välisõhu kaitse seadus",
+      "law_files": [
+        "valisohu_kaitse_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32008L0051",
+      "directive_iri": "estleg:EU_32008L0051",
+      "national_title": "RELVASEADUS",
+      "matched_law_name": "relvaseadus",
+      "matched_source_act": "Relvaseadus",
+      "law_files": [
+        "relvaseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32008L0056",
+      "directive_iri": "estleg:EU_32008L0056",
+      "national_title": "Veeseadus",
+      "matched_law_name": "veeseadus",
+      "matched_source_act": "Veeseadus",
+      "law_files": [
+        "veeseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32008L0057",
+      "directive_iri": "estleg:EU_32008L0057",
+      "national_title": "Raudteeseadus1",
+      "matched_law_name": "raudteeseadus",
+      "matched_source_act": "Raudteeseadus",
+      "law_files": [
+        "raudteeseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32008L0057",
+      "directive_iri": "estleg:EU_32008L0057",
+      "national_title": "Toote nõuetele vastavuse seadus",
+      "matched_law_name": "toote_nouetele_vastavuse_seadus",
+      "matched_source_act": "Toote nõuetele vastavuse seadus",
+      "law_files": [
+        "toote_nouetele_vastavuse_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32008L0062",
+      "directive_iri": "estleg:EU_32008L0062",
+      "national_title": "TAIMEDE PALJUNDAMISE JA SORDIKAITSE SEADUS",
+      "matched_law_name": "taimede_paljundamise_ja_sordikaitse_seadus",
+      "matched_source_act": "Taimede paljundamise ja sordikaitse seadus",
+      "law_files": [
+        "taimede_paljundamise_ja_sordikaitse_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32008L0068",
+      "directive_iri": "estleg:EU_32008L0068",
+      "national_title": "RAUDTEESEADUS1",
+      "matched_law_name": "raudteeseadus",
+      "matched_source_act": "Raudteeseadus",
+      "law_files": [
+        "raudteeseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32008L0073",
+      "directive_iri": "estleg:EU_32008L0073",
+      "national_title": "LOOMATAUDITÕRJE SEADUS1",
+      "matched_law_name": "loomatauditorje_seadus",
+      "matched_source_act": "Loomatauditõrje seadus",
+      "law_files": [
+        "loomatauditorje_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32008L0075",
+      "directive_iri": "estleg:EU_32008L0075",
+      "national_title": "BIOTSIIDISEADUS1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32008L0077",
+      "directive_iri": "estleg:EU_32008L0077",
+      "national_title": "BIOTSIIDISEADUS1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32008L0078",
+      "directive_iri": "estleg:EU_32008L0078",
+      "national_title": "BIOTSIIDISEADUS1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32008L0079",
+      "directive_iri": "estleg:EU_32008L0079",
+      "national_title": "BIOTSIIDISEADUS1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32008L0080",
+      "directive_iri": "estleg:EU_32008L0080",
+      "national_title": "BIOTSIIDISEADUS1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32008L0081",
+      "directive_iri": "estleg:EU_32008L0081",
+      "national_title": "BIOTSIIDISEADUS1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32008L0085",
+      "directive_iri": "estleg:EU_32008L0085",
+      "national_title": "BIOTSIIDISEADUS1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32008L0086",
+      "directive_iri": "estleg:EU_32008L0086",
+      "national_title": "BIOTSIIDISEADUS1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32008L0090",
+      "directive_iri": "estleg:EU_32008L0090",
+      "national_title": "TAIMEDE PALJUNDAMISE JA SORDIKAITSE SEADUSE, MAAELU JA PÕLLUMAJANDUSTURU KORRALDAMISE SEADUSE NING RIIGILÕIVUSEADUSE MUUTMISE SEADUS",
+      "matched_law_name": "maaelu_ja_pollumajandusturu_korraldamise_seadus",
+      "matched_source_act": "Maaelu ja põllumajandusturu korraldamise seadus",
+      "law_files": [
+        "maaelu_ja_pollumajandusturu_korraldamise_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32008L0090",
+      "directive_iri": "estleg:EU_32008L0090",
+      "national_title": "TAIMEDE PALJUNDAMISE JA SORDIKAITSE SEADUS",
+      "matched_law_name": "taimede_paljundamise_ja_sordikaitse_seadus",
+      "matched_source_act": "Taimede paljundamise ja sordikaitse seadus",
+      "law_files": [
+        "taimede_paljundamise_ja_sordikaitse_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32008L0090",
+      "directive_iri": "estleg:EU_32008L0090",
+      "national_title": "GENEETILISELT MUUNDATUD ORGANISMIDE KESKKONDA VIIMISE SEADUS1",
+      "matched_law_name": "geneetiliselt_muundatud_organismide_keskkonda_viimise_seadus",
+      "matched_source_act": "Geneetiliselt muundatud organismide keskkonda viimise seadus",
+      "law_files": [
+        "geneetiliselt_muundatud_organismide_keskkonda_viimise_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32008L0096",
+      "directive_iri": "estleg:EU_32008L0096",
+      "national_title": "Teeseadus1",
+      "matched_law_name": "teeseadus",
+      "matched_source_act": "Teeseadus",
+      "law_files": [
+        "teeseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32008L0098",
+      "directive_iri": "estleg:EU_32008L0098",
+      "national_title": "Jäätmeseadus1",
+      "matched_law_name": "jaatmeseadus",
+      "matched_source_act": "Jäätmeseadus",
+      "law_files": [
+        "jaatmeseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32008L0099",
+      "directive_iri": "estleg:EU_32008L0099",
+      "national_title": "Karistusseadustik1",
+      "matched_law_name": "karistusseadustik",
+      "matched_source_act": "Karistusseadustik",
+      "law_files": [
+        "karistusseadustik_osa1_peep.json",
+        "karistusseadustik_osa2_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32008L0101",
+      "directive_iri": "estleg:EU_32008L0101",
+      "national_title": "Välisõhu kaitse seadus",
+      "matched_law_name": "valisohu_kaitse_seadus",
+      "matched_source_act": "Välisõhu kaitse seadus",
+      "law_files": [
+        "valisohu_kaitse_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32008L0110",
+      "directive_iri": "estleg:EU_32008L0110",
+      "national_title": "Raudteeseadus1",
+      "matched_law_name": "raudteeseadus",
+      "matched_source_act": "Raudteeseadus",
+      "law_files": [
+        "raudteeseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32008L0114",
+      "directive_iri": "estleg:EU_32008L0114",
+      "national_title": "Hädaolukorra seadus",
+      "matched_law_name": "hadaolukorra_seadus",
+      "matched_source_act": "Hädaolukorra seadus",
+      "law_files": [
+        "hadaolukorra_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32008L0115",
+      "directive_iri": "estleg:EU_32008L0115",
+      "national_title": "Väljasõidukohustuse ja sissesõidukeelu seadus",
+      "matched_law_name": "valjasoidukohustuse_ja_sissesoidukeelu_seadus",
+      "matched_source_act": "Väljasõidukohustuse ja sissesõidukeelu seadus",
+      "law_files": [
+        "valjasoidukohustuse_ja_sissesoidukeelu_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32008L0117",
+      "directive_iri": "estleg:EU_32008L0117",
+      "national_title": "KÄIBEMAKSUSEADUS1",
+      "matched_law_name": "kaibemaksuseadus",
+      "matched_source_act": "Käibemaksuseadus",
+      "law_files": [
+        "kaibemaksuseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32008L0122",
+      "directive_iri": "estleg:EU_32008L0122",
+      "national_title": "Võlaõigusseaduse, sotsiaalmaksuseaduse ja mittetulundusühingute seaduse muutmise seadus",
+      "matched_law_name": "mittetulundusuhingute_seadus",
+      "matched_source_act": "Mittetulundusühingute seadus",
+      "law_files": [
+        "mittetulundusuhingute_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32008L0122",
+      "directive_iri": "estleg:EU_32008L0122",
+      "national_title": "Võlaõigusseadus",
+      "matched_law_name": "volaigusseadus",
+      "matched_source_act": "Võlaõigusseadus",
+      "law_files": [
+        "volaigusseadus_osa11_peep.json",
+        "volaigusseadus_osa12_peep.json",
+        "volaigusseadus_osa13_peep.json",
+        "volaigusseadus_osa1_peep.json",
+        "volaigusseadus_osa3_peep.json",
+        "volaigusseadus_osa4_peep.json",
+        "volaigusseadus_osa5_peep.json",
+        "volaigusseadus_osa7_peep.json",
+        "volaigusseadus_osa8_peep.json",
+        "volaigusseadus_osa9_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0004",
+      "directive_iri": "estleg:EU_32009L0004",
+      "national_title": "Liiklusseadus1",
+      "matched_law_name": "liiklusseadus",
+      "matched_source_act": "Liiklusseadus",
+      "law_files": [
+        "liiklusseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0012",
+      "directive_iri": "estleg:EU_32009L0012",
+      "national_title": "Lennundusseadus1",
+      "matched_law_name": "lennundusseadus",
+      "matched_source_act": "Lennundusseadus",
+      "law_files": [
+        "lennundusseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0014",
+      "directive_iri": "estleg:EU_32009L0014",
+      "national_title": "TAGATISFONDI SEADUS",
+      "matched_law_name": "tagatisfondi_seadus",
+      "matched_source_act": "Tagatisfondi seadus",
+      "law_files": [
+        "tagatisfondi_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0015",
+      "directive_iri": "estleg:EU_32009L0015",
+      "national_title": "Meresõiduohutuse seadus1",
+      "matched_law_name": "meresoiduohutuse_seadus",
+      "matched_source_act": "Meresõiduohutuse seadus",
+      "law_files": [
+        "meresoiduohutuse_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0016",
+      "directive_iri": "estleg:EU_32009L0016",
+      "national_title": "Sadamaseadus1",
+      "matched_law_name": "sadamaseadus",
+      "matched_source_act": "Sadamaseadus",
+      "law_files": [
+        "sadamaseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0016",
+      "directive_iri": "estleg:EU_32009L0016",
+      "national_title": "Meresõiduohutuse seadus1",
+      "matched_law_name": "meresoiduohutuse_seadus",
+      "matched_source_act": "Meresõiduohutuse seadus",
+      "law_files": [
+        "meresoiduohutuse_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0017",
+      "directive_iri": "estleg:EU_32009L0017",
+      "national_title": "Meresõiduohutuse seadus1",
+      "matched_law_name": "meresoiduohutuse_seadus",
+      "matched_source_act": "Meresõiduohutuse seadus",
+      "law_files": [
+        "meresoiduohutuse_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0018",
+      "directive_iri": "estleg:EU_32009L0018",
+      "national_title": "Meresõiduohutuse seadus1",
+      "matched_law_name": "meresoiduohutuse_seadus",
+      "matched_source_act": "Meresõiduohutuse seadus",
+      "law_files": [
+        "meresoiduohutuse_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0018",
+      "directive_iri": "estleg:EU_32009L0018",
+      "national_title": "Isikuandmete kaitse seadus1",
+      "matched_law_name": "isikuandmete_kaitse_seadus",
+      "matched_source_act": "Isikuandmete kaitse seadus",
+      "law_files": [
+        "isikuandmete_kaitse_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0018",
+      "directive_iri": "estleg:EU_32009L0018",
+      "national_title": "Raudteeseadus1",
+      "matched_law_name": "raudteeseadus",
+      "matched_source_act": "Raudteeseadus",
+      "law_files": [
+        "raudteeseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0018",
+      "directive_iri": "estleg:EU_32009L0018",
+      "national_title": "Lennundusseadus1",
+      "matched_law_name": "lennundusseadus",
+      "matched_source_act": "Lennundusseadus",
+      "law_files": [
+        "lennundusseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0020",
+      "directive_iri": "estleg:EU_32009L0020",
+      "national_title": "Meresõiduohutuse seadus1",
+      "matched_law_name": "meresoiduohutuse_seadus",
+      "matched_source_act": "Meresõiduohutuse seadus",
+      "law_files": [
+        "meresoiduohutuse_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0020",
+      "directive_iri": "estleg:EU_32009L0020",
+      "national_title": "Kaubandusliku meresõidu seadus1",
+      "matched_law_name": "meresoidu_seadus",
+      "matched_source_act": "Meresõidu seadus",
+      "law_files": [
+        "meresoidu_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0021",
+      "directive_iri": "estleg:EU_32009L0021",
+      "national_title": "Meresõiduohutuse seadus1",
+      "matched_law_name": "meresoiduohutuse_seadus",
+      "matched_source_act": "Meresõiduohutuse seadus",
+      "law_files": [
+        "meresoiduohutuse_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0028",
+      "directive_iri": "estleg:EU_32009L0028",
+      "national_title": "Riigihangete seadus1",
+      "matched_law_name": "riigihangete_seadus",
+      "matched_source_act": "Riigihangete seadus",
+      "law_files": [
+        "riigihangete_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0028",
+      "directive_iri": "estleg:EU_32009L0028",
+      "national_title": "Alkoholi-, tubaka-, kütuse- ja elektriaktsiisi seadus",
+      "matched_law_name": "alkoholi_tubaka_kutuse_ja_elektriaktsiisi_seadus",
+      "matched_source_act": "Alkoholi-, tubaka-, kütuse- ja elektriaktsiisi seadus",
+      "law_files": [
+        "alkoholi_tubaka_kutuse_ja_elektriaktsiisi_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0028",
+      "directive_iri": "estleg:EU_32009L0028",
+      "national_title": "Kutseseadus",
+      "matched_law_name": "kutseseadus",
+      "matched_source_act": "Kutseseadus",
+      "law_files": [
+        "kutseseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0028",
+      "directive_iri": "estleg:EU_32009L0028",
+      "national_title": "Planeerimisseadus",
+      "matched_law_name": "planeerimisseadus",
+      "matched_source_act": "Planeerimisseadus",
+      "law_files": [
+        "planeerimisseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0028",
+      "directive_iri": "estleg:EU_32009L0028",
+      "national_title": "Vabariigi Valitsuse seadus",
+      "matched_law_name": "vabariigi_valitsuse_seadus",
+      "matched_source_act": "Vabariigi Valitsuse seadus",
+      "law_files": [
+        "vabariigi_valitsuse_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0028",
+      "directive_iri": "estleg:EU_32009L0028",
+      "national_title": "Elektrituruseadus",
+      "matched_law_name": "elektrituruseadus",
+      "matched_source_act": "Elektrituruseadus",
+      "law_files": [
+        "elektrituruseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0028",
+      "directive_iri": "estleg:EU_32009L0028",
+      "national_title": "Kaugkütteseadus",
+      "matched_law_name": "kaugkutteseadus",
+      "matched_source_act": "Kaugkütteseadus",
+      "law_files": [
+        "kaugkutteseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0028",
+      "directive_iri": "estleg:EU_32009L0028",
+      "national_title": "Riigilõivuseadus",
+      "matched_law_name": "riigiloivuseadus",
+      "matched_source_act": "Riigilõivuseadus",
+      "law_files": [
+        "riigiloivuseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0028",
+      "directive_iri": "estleg:EU_32009L0028",
+      "national_title": "Tarbijakaitseseadus",
+      "matched_law_name": "tarbijakaitseseadus",
+      "matched_source_act": "Tarbijakaitseseadus",
+      "law_files": [
+        "tarbijakaitseseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0029",
+      "directive_iri": "estleg:EU_32009L0029",
+      "national_title": "Välisõhu kaitse seadus",
+      "matched_law_name": "valisohu_kaitse_seadus",
+      "matched_source_act": "Välisõhu kaitse seadus",
+      "law_files": [
+        "valisohu_kaitse_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0031",
+      "directive_iri": "estleg:EU_32009L0031",
+      "national_title": "Maapõueseadus1",
+      "matched_law_name": "maapoueseadus",
+      "matched_source_act": "Maapõueseadus",
+      "law_files": [
+        "maapoueseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0031",
+      "directive_iri": "estleg:EU_32009L0031",
+      "national_title": "Keskkonnavastutuse seadus",
+      "matched_law_name": "keskkonnavastutuse_seadus",
+      "matched_source_act": "Keskkonnavastutuse seadus",
+      "law_files": [
+        "keskkonnavastutuse_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0031",
+      "directive_iri": "estleg:EU_32009L0031",
+      "national_title": "Keskkonnamõju hindamise ja keskkonnajuhtimissüsteemi seadus",
+      "matched_law_name": "keskkonnamoju_hindamise_ja_keskkonnajuhtimissusteemi_seadus",
+      "matched_source_act": "Keskkonnamõju hindamise ja keskkonnajuhtimissüsteemi seadus",
+      "law_files": [
+        "keskkonnamoju_hindamise_ja_keskkonnajuhtimissusteemi_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0031",
+      "directive_iri": "estleg:EU_32009L0031",
+      "national_title": "Välisõhu kaitse seadus",
+      "matched_law_name": "valisohu_kaitse_seadus",
+      "matched_source_act": "Välisõhu kaitse seadus",
+      "law_files": [
+        "valisohu_kaitse_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0031",
+      "directive_iri": "estleg:EU_32009L0031",
+      "national_title": "Veeseadus",
+      "matched_law_name": "veeseadus",
+      "matched_source_act": "Veeseadus",
+      "law_files": [
+        "veeseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0031",
+      "directive_iri": "estleg:EU_32009L0031",
+      "national_title": "Saastuse kompleksse vältimise ja kontrollimise seadus",
+      "matched_law_name": "saastuse_kompleksse_valtimise_ja_kontrollimise_seadus",
+      "matched_source_act": "Saastuse kompleksse vältimise ja kontrollimise seadus",
+      "law_files": [
+        "saastuse_kompleksse_valtimise_ja_kontrollimise_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0031",
+      "directive_iri": "estleg:EU_32009L0031",
+      "national_title": "Jäätmeseadus1",
+      "matched_law_name": "jaatmeseadus",
+      "matched_source_act": "Jäätmeseadus",
+      "law_files": [
+        "jaatmeseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0033",
+      "directive_iri": "estleg:EU_32009L0033",
+      "national_title": "RIIGIHANGETE SEADUS1",
+      "matched_law_name": "riigihangete_seadus",
+      "matched_source_act": "Riigihangete seadus",
+      "law_files": [
+        "riigihangete_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0038",
+      "directive_iri": "estleg:EU_32009L0038",
+      "national_title": "Töötajate üleühenduselise kaasamise seadus1",
+      "matched_law_name": "tootajate_uleuhenduselise_kaasamise_seadus",
+      "matched_source_act": "Töötajate üleühenduselise kaasamise seadus",
+      "law_files": [
+        "tootajate_uleuhenduselise_kaasamise_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0043",
+      "directive_iri": "estleg:EU_32009L0043",
+      "national_title": "Karistusseadustik1",
+      "matched_law_name": "karistusseadustik",
+      "matched_source_act": "Karistusseadustik",
+      "law_files": [
+        "karistusseadustik_osa1_peep.json",
+        "karistusseadustik_osa2_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0043",
+      "directive_iri": "estleg:EU_32009L0043",
+      "national_title": "Strateegilise kauba seadus1",
+      "matched_law_name": "strateegilise_kauba_seadus",
+      "matched_source_act": "Strateegilise kauba seadus",
+      "law_files": [
+        "strateegilise_kauba_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0044",
+      "directive_iri": "estleg:EU_32009L0044",
+      "national_title": "Asjaõigusseadus1",
+      "matched_law_name": "asjaoigusseadus",
+      "matched_source_act": "Asjaõigusseadus",
+      "law_files": [
+        "asjaoigusseadus_osa10_peep.json",
+        "asjaoigusseadus_osa11_peep.json",
+        "asjaoigusseadus_osa1_peep.json",
+        "asjaoigusseadus_osa2_peep.json",
+        "asjaoigusseadus_osa3_peep.json",
+        "asjaoigusseadus_osa4_peep.json",
+        "asjaoigusseadus_osa5_peep.json",
+        "asjaoigusseadus_osa6-13_peep.json",
+        "asjaoigusseadus_osa7_peep.json",
+        "asjaoigusseadus_osa8_peep.json",
+        "asjaoigusseadus_osa9_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0044",
+      "directive_iri": "estleg:EU_32009L0044",
+      "national_title": "Väärtpaberituru seadus",
+      "matched_law_name": "vaartpaberituru_seadus",
+      "matched_source_act": "Väärtpaberituru seadus",
+      "law_files": [
+        "vaartpaberituru_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0044",
+      "directive_iri": "estleg:EU_32009L0044",
+      "national_title": "Asjaõigusseaduse rakendamise seadus",
+      "matched_law_name": "asjaoigusseaduse_rakendamise_seadus",
+      "matched_source_act": "Asjaõigusseaduse rakendamise seadus",
+      "law_files": [
+        "asjaoigusseaduse_rakendamise_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0044",
+      "directive_iri": "estleg:EU_32009L0044",
+      "national_title": "Pankrotiseadus",
+      "matched_law_name": "pankrotiseadus",
+      "matched_source_act": "Pankrotiseadus",
+      "law_files": [
+        "pankrotiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0044",
+      "directive_iri": "estleg:EU_32009L0044",
+      "national_title": "Krediidiasutuste seadus1",
+      "matched_law_name": "krediidiasutuste_seadus",
+      "matched_source_act": "Krediidiasutuste seadus",
+      "law_files": [
+        "krediidiasutuste_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0044",
+      "directive_iri": "estleg:EU_32009L0044",
+      "national_title": "Kindlustustegevuse seadus1",
+      "matched_law_name": "kindlustustegevuse_seadus",
+      "matched_source_act": "Kindlustustegevuse seadus",
+      "law_files": [
+        "kindlustustegevuse_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0044",
+      "directive_iri": "estleg:EU_32009L0044",
+      "national_title": "Võlaõigusseadus",
+      "matched_law_name": "volaigusseadus",
+      "matched_source_act": "Võlaõigusseadus",
+      "law_files": [
+        "volaigusseadus_osa11_peep.json",
+        "volaigusseadus_osa12_peep.json",
+        "volaigusseadus_osa13_peep.json",
+        "volaigusseadus_osa1_peep.json",
+        "volaigusseadus_osa3_peep.json",
+        "volaigusseadus_osa4_peep.json",
+        "volaigusseadus_osa5_peep.json",
+        "volaigusseadus_osa7_peep.json",
+        "volaigusseadus_osa8_peep.json",
+        "volaigusseadus_osa9_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0048",
+      "directive_iri": "estleg:EU_32009L0048",
+      "national_title": "TOOTE NÕUETELE VASTAVUSE SEADUS1",
+      "matched_law_name": "toote_nouetele_vastavuse_seadus",
+      "matched_source_act": "Toote nõuetele vastavuse seadus",
+      "law_files": [
+        "toote_nouetele_vastavuse_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0049",
+      "directive_iri": "estleg:EU_32009L0049",
+      "national_title": "RAAMATUPIDAMISE SEADUS",
+      "matched_law_name": "raamatupidamise_seadus",
+      "matched_source_act": "Raamatupidamise seadus",
+      "law_files": [
+        "raamatupidamise_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0050",
+      "directive_iri": "estleg:EU_32009L0050",
+      "national_title": "«Välismaalaste seaduses» sätestatud teavitamiskohustuse täitmise kord",
+      "matched_law_name": "valismaalaste_seadus",
+      "matched_source_act": "Välismaalaste seadus",
+      "law_files": [
+        "valismaalaste_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0052",
+      "directive_iri": "estleg:EU_32009L0052",
+      "national_title": "Võlaõigusseadus",
+      "matched_law_name": "volaigusseadus",
+      "matched_source_act": "Võlaõigusseadus",
+      "law_files": [
+        "volaigusseadus_osa11_peep.json",
+        "volaigusseadus_osa12_peep.json",
+        "volaigusseadus_osa13_peep.json",
+        "volaigusseadus_osa1_peep.json",
+        "volaigusseadus_osa3_peep.json",
+        "volaigusseadus_osa4_peep.json",
+        "volaigusseadus_osa5_peep.json",
+        "volaigusseadus_osa7_peep.json",
+        "volaigusseadus_osa8_peep.json",
+        "volaigusseadus_osa9_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0052",
+      "directive_iri": "estleg:EU_32009L0052",
+      "national_title": "Riigivastutuse seadus",
+      "matched_law_name": "riigivastutuse_seadus",
+      "matched_source_act": "Riigivastutuse seadus",
+      "law_files": [
+        "riigivastutuse_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0052",
+      "directive_iri": "estleg:EU_32009L0052",
+      "national_title": "Töölepingu seadus",
+      "matched_law_name": "toolepinguseadus",
+      "matched_source_act": "Töölepingu seadus",
+      "law_files": [
+        "toolepinguseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0052",
+      "directive_iri": "estleg:EU_32009L0052",
+      "national_title": "Karistusseadustik",
+      "matched_law_name": "karistusseadustik",
+      "matched_source_act": "Karistusseadustik",
+      "law_files": [
+        "karistusseadustik_osa1_peep.json",
+        "karistusseadustik_osa2_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0052",
+      "directive_iri": "estleg:EU_32009L0052",
+      "national_title": "Individuaalse töövaidluse lahendamise seadus",
+      "matched_law_name": "individuaalse_toovaidluse_lahendamise_seadus",
+      "matched_source_act": "Individuaalse töövaidluse lahendamise seadus",
+      "law_files": [
+        "individuaalse_toovaidluse_lahendamise_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0052",
+      "directive_iri": "estleg:EU_32009L0052",
+      "national_title": "Haldusmenetluse seadus",
+      "matched_law_name": "haldusmenetluse",
+      "matched_source_act": "Haldusmenetluse seadus",
+      "law_files": [
+        "haldusmenetluse_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0052",
+      "directive_iri": "estleg:EU_32009L0052",
+      "national_title": "„Välismaalaste seaduses“ sätestatud säilitamiskohustuse täitmiseks vajalike andmete ja dokumentide loetelu",
+      "matched_law_name": "valismaalaste_seadus",
+      "matched_source_act": "Välismaalaste seadus",
+      "law_files": [
+        "valismaalaste_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0052",
+      "directive_iri": "estleg:EU_32009L0052",
+      "national_title": "Tsiviilseadustiku üldosa seadus",
+      "matched_law_name": "tsiviilseadustiku_uldosa_seadus",
+      "matched_source_act": "Tsiviilseadustiku üldosa seadus",
+      "law_files": [
+        "tsiviilseadustiku_uldosa_seadus_osa2_peep.json",
+        "tsiviilseadustiku_uldosa_seadus_osa4_peep.json",
+        "tsiviilseadustiku_uldosa_seadus_osa7_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0065",
+      "directive_iri": "estleg:EU_32009L0065",
+      "national_title": "Makseasutuste ja e-raha asutuste seaduse ja sellega seonduvate seaduste ning investeerimisfondide seaduse muutmise seadus",
+      "matched_law_name": "makseasutuste_ja_e_raha_asutuste_seadus",
+      "matched_source_act": "Makseasutuste ja e-raha asutuste seadus",
+      "law_files": [
+        "makseasutuste_ja_e_raha_asutuste_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0069",
+      "directive_iri": "estleg:EU_32009L0069",
+      "national_title": "KÄIBEMAKSUSEADUS1",
+      "matched_law_name": "kaibemaksuseadus",
+      "matched_source_act": "Käibemaksuseadus",
+      "law_files": [
+        "kaibemaksuseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0071",
+      "directive_iri": "estleg:EU_32009L0071",
+      "national_title": "Kiirgusseadus1",
+      "matched_law_name": "kiirgusseadus",
+      "matched_source_act": "Kiirgusseadus",
+      "law_files": [
+        "kiirgusseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0071",
+      "directive_iri": "estleg:EU_32009L0071",
+      "national_title": "Riigi Teataja seadus",
+      "matched_law_name": "riigi_teataja_seadus",
+      "matched_source_act": "Riigi Teataja seadus",
+      "law_files": [
+        "riigi_teataja_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0071",
+      "directive_iri": "estleg:EU_32009L0071",
+      "national_title": "Avaliku teabe seadus",
+      "matched_law_name": "avaliku_teabe_seadus",
+      "matched_source_act": "Avaliku teabe seadus",
+      "law_files": [
+        "avaliku_teabe_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0072",
+      "directive_iri": "estleg:EU_32009L0072",
+      "national_title": "Elektrituruseadus1",
+      "matched_law_name": "elektrituruseadus",
+      "matched_source_act": "Elektrituruseadus",
+      "law_files": [
+        "elektrituruseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0073",
+      "directive_iri": "estleg:EU_32009L0073",
+      "national_title": "Tarbijakaitseseadus1",
+      "matched_law_name": "tarbijakaitseseadus",
+      "matched_source_act": "Tarbijakaitseseadus",
+      "law_files": [
+        "tarbijakaitseseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0081",
+      "directive_iri": "estleg:EU_32009L0081",
+      "national_title": "Riigihangete seadus1",
+      "matched_law_name": "riigihangete_seadus",
+      "matched_source_act": "Riigihangete seadus",
+      "law_files": [
+        "riigihangete_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0084",
+      "directive_iri": "estleg:EU_32009L0084",
+      "national_title": "BIOTSIIDISEADUS1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0085",
+      "directive_iri": "estleg:EU_32009L0085",
+      "national_title": "BIOTSIIDISEADUS1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0086",
+      "directive_iri": "estleg:EU_32009L0086",
+      "national_title": "BIOTSIIDISEADUS1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0087",
+      "directive_iri": "estleg:EU_32009L0087",
+      "national_title": "BIOTSIIDISEADUS1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0088",
+      "directive_iri": "estleg:EU_32009L0088",
+      "national_title": "BIOTSIIDISEADUS1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0089",
+      "directive_iri": "estleg:EU_32009L0089",
+      "national_title": "BIOTSIIDISEADUS1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0090",
+      "directive_iri": "estleg:EU_32009L0090",
+      "national_title": "Veeseadus",
+      "matched_law_name": "veeseadus",
+      "matched_source_act": "Veeseadus",
+      "law_files": [
+        "veeseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0091",
+      "directive_iri": "estleg:EU_32009L0091",
+      "national_title": "BIOTSIIDISEADUS1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0092",
+      "directive_iri": "estleg:EU_32009L0092",
+      "national_title": "BIOTSIIDISEADUS1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0093",
+      "directive_iri": "estleg:EU_32009L0093",
+      "national_title": "BIOTSIIDISEADUS1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0094",
+      "directive_iri": "estleg:EU_32009L0094",
+      "national_title": "BIOTSIIDISEADUS1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0095",
+      "directive_iri": "estleg:EU_32009L0095",
+      "national_title": "BIOTSIIDISEADUS1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0096",
+      "directive_iri": "estleg:EU_32009L0096",
+      "national_title": "BIOTSIIDISEADUS1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0098",
+      "directive_iri": "estleg:EU_32009L0098",
+      "national_title": "BIOTSIIDISEADUS1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0099",
+      "directive_iri": "estleg:EU_32009L0099",
+      "national_title": "BIOTSIIDISEADUS1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0107",
+      "directive_iri": "estleg:EU_32009L0107",
+      "national_title": "BIOTSIIDISEADUS1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0109",
+      "directive_iri": "estleg:EU_32009L0109",
+      "national_title": "Väärtpaberituru seadus1",
+      "matched_law_name": "vaartpaberituru_seadus",
+      "matched_source_act": "Väärtpaberituru seadus",
+      "law_files": [
+        "vaartpaberituru_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0109",
+      "directive_iri": "estleg:EU_32009L0109",
+      "national_title": "Makseasutuste ja e-raha asutuste seadus1",
+      "matched_law_name": "makseasutuste_ja_e_raha_asutuste_seadus",
+      "matched_source_act": "Makseasutuste ja e-raha asutuste seadus",
+      "law_files": [
+        "makseasutuste_ja_e_raha_asutuste_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0109",
+      "directive_iri": "estleg:EU_32009L0109",
+      "national_title": "Krediidiasutuste seadus1",
+      "matched_law_name": "krediidiasutuste_seadus",
+      "matched_source_act": "Krediidiasutuste seadus",
+      "law_files": [
+        "krediidiasutuste_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0109",
+      "directive_iri": "estleg:EU_32009L0109",
+      "national_title": "Äriseadustik",
+      "matched_law_name": "ariseadustik1",
+      "matched_source_act": "Äriseadustik1",
+      "law_files": [
+        "ariseadustik1_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0109",
+      "directive_iri": "estleg:EU_32009L0109",
+      "national_title": "Kindlustustegevuse seadus1",
+      "matched_law_name": "kindlustustegevuse_seadus",
+      "matched_source_act": "Kindlustustegevuse seadus",
+      "law_files": [
+        "kindlustustegevuse_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0109",
+      "directive_iri": "estleg:EU_32009L0109",
+      "national_title": "Investeerimisfondide seadus1",
+      "matched_law_name": "investeerimisfondide_seadus",
+      "matched_source_act": "Investeerimisfondide seadus",
+      "law_files": [
+        "investeerimisfondide_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0110",
+      "directive_iri": "estleg:EU_32009L0110",
+      "national_title": "Rahapesu ja terrorismi rahastamise tõkestamise seadus1",
+      "matched_law_name": "rahapesu_ja_terrorismi_rahastamise_tokestamise_seadus",
+      "matched_source_act": "Rahapesu ja terrorismi rahastamise tõkestamise seadus",
+      "law_files": [
+        "rahapesu_ja_terrorismi_rahastamise_tokestamise_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0110",
+      "directive_iri": "estleg:EU_32009L0110",
+      "national_title": "Krediidiasutuste seadus1",
+      "matched_law_name": "krediidiasutuste_seadus",
+      "matched_source_act": "Krediidiasutuste seadus",
+      "law_files": [
+        "krediidiasutuste_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0110",
+      "directive_iri": "estleg:EU_32009L0110",
+      "national_title": "Makseasutuste ja e-raha asutuste seadus",
+      "matched_law_name": "makseasutuste_ja_e_raha_asutuste_seadus",
+      "matched_source_act": "Makseasutuste ja e-raha asutuste seadus",
+      "law_files": [
+        "makseasutuste_ja_e_raha_asutuste_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0110",
+      "directive_iri": "estleg:EU_32009L0110",
+      "national_title": "Finantsinspektsiooni seadus",
+      "matched_law_name": "finantsinspektsiooni_seadus",
+      "matched_source_act": "Finantsinspektsiooni seadus",
+      "law_files": [
+        "finantsinspektsiooni_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0111",
+      "directive_iri": "estleg:EU_32009L0111",
+      "national_title": "Väärtpaberituru seadus",
+      "matched_law_name": "vaartpaberituru_seadus",
+      "matched_source_act": "Väärtpaberituru seadus",
+      "law_files": [
+        "vaartpaberituru_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0111",
+      "directive_iri": "estleg:EU_32009L0111",
+      "national_title": "Finantsinspektsiooni seadus1",
+      "matched_law_name": "finantsinspektsiooni_seadus",
+      "matched_source_act": "Finantsinspektsiooni seadus",
+      "law_files": [
+        "finantsinspektsiooni_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0111",
+      "directive_iri": "estleg:EU_32009L0111",
+      "national_title": "Investeerimisfondide seadus1",
+      "matched_law_name": "investeerimisfondide_seadus",
+      "matched_source_act": "Investeerimisfondide seadus",
+      "law_files": [
+        "investeerimisfondide_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0111",
+      "directive_iri": "estleg:EU_32009L0111",
+      "national_title": "Krediidiasutuste seadus1",
+      "matched_law_name": "krediidiasutuste_seadus",
+      "matched_source_act": "Krediidiasutuste seadus",
+      "law_files": [
+        "krediidiasutuste_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0123",
+      "directive_iri": "estleg:EU_32009L0123",
+      "national_title": "Veeseadus",
+      "matched_law_name": "veeseadus",
+      "matched_source_act": "Veeseadus",
+      "law_files": [
+        "veeseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0123",
+      "directive_iri": "estleg:EU_32009L0123",
+      "national_title": "Karistusseadustik1",
+      "matched_law_name": "karistusseadustik",
+      "matched_source_act": "Karistusseadustik",
+      "law_files": [
+        "karistusseadustik_osa1_peep.json",
+        "karistusseadustik_osa2_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0125",
+      "directive_iri": "estleg:EU_32009L0125",
+      "national_title": "TOOTE NÕUETELE VASTAVUSE SEADUS1",
+      "matched_law_name": "toote_nouetele_vastavuse_seadus",
+      "matched_source_act": "Toote nõuetele vastavuse seadus",
+      "law_files": [
+        "toote_nouetele_vastavuse_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0127",
+      "directive_iri": "estleg:EU_32009L0127",
+      "national_title": "MASINA OHUTUSE SEADUS1",
+      "matched_law_name": "masina_ohutuse_seadus",
+      "matched_source_act": "Masina ohutuse seadus",
+      "law_files": [
+        "masina_ohutuse_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0128",
+      "directive_iri": "estleg:EU_32009L0128",
+      "national_title": "Taimekaitseseaduse muutmise ja sellega seonduvalt teiste seaduste muutmise seadus",
+      "matched_law_name": "taimekaitseseadus",
+      "matched_source_act": "Taimekaitseseadus",
+      "law_files": [
+        "taimekaitseseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0136",
+      "directive_iri": "estleg:EU_32009L0136",
+      "national_title": "Elektroonilise side seadus1",
+      "matched_law_name": "elektroonilise_side_seadus",
+      "matched_source_act": "Elektroonilise side seadus",
+      "law_files": [
+        "elektroonilise_side_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0136",
+      "directive_iri": "estleg:EU_32009L0136",
+      "national_title": "ELEKTROONILISE SIDE SEADUSE JA INFOÜHISKONNA TEENUSE SEADUSE MUUTMISE SEADUS",
+      "matched_law_name": "infouhiskonna_teenuse_seadus",
+      "matched_source_act": "Infoühiskonna teenuse seadus",
+      "law_files": [
+        "infouhiskonna_teenuse_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0140",
+      "directive_iri": "estleg:EU_32009L0140",
+      "national_title": "Elektroonilise side seadus1",
+      "matched_law_name": "elektroonilise_side_seadus",
+      "matched_source_act": "Elektroonilise side seadus",
+      "law_files": [
+        "elektroonilise_side_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0143",
+      "directive_iri": "estleg:EU_32009L0143",
+      "national_title": "Taimekaitseseadus1",
+      "matched_law_name": "taimekaitseseadus",
+      "matched_source_act": "Taimekaitseseadus",
+      "law_files": [
+        "taimekaitseseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0145",
+      "directive_iri": "estleg:EU_32009L0145",
+      "national_title": "TAIMEDE PALJUNDAMISE JA SORDIKAITSE SEADUS",
+      "matched_law_name": "taimede_paljundamise_ja_sordikaitse_seadus",
+      "matched_source_act": "Taimede paljundamise ja sordikaitse seadus",
+      "law_files": [
+        "taimede_paljundamise_ja_sordikaitse_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0149",
+      "directive_iri": "estleg:EU_32009L0149",
+      "national_title": "Raudteeseadus1",
+      "matched_law_name": "raudteeseadus",
+      "matched_source_act": "Raudteeseadus",
+      "law_files": [
+        "raudteeseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0150",
+      "directive_iri": "estleg:EU_32009L0150",
+      "national_title": "BIOTSIIDISEADUS1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0151",
+      "directive_iri": "estleg:EU_32009L0151",
+      "national_title": "BIOTSIIDISEADUS1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32009L0162",
+      "directive_iri": "estleg:EU_32009L0162",
+      "national_title": "Käibemaksuseadus",
+      "matched_law_name": "kaibemaksuseadus",
+      "matched_source_act": "Käibemaksuseadus",
+      "law_files": [
+        "kaibemaksuseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32010L0005",
+      "directive_iri": "estleg:EU_32010L0005",
+      "national_title": "BIOTSIIDISEADUS",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32010L0007",
+      "directive_iri": "estleg:EU_32010L0007",
+      "national_title": "BIOTSIIDISEADUS",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32010L0008",
+      "directive_iri": "estleg:EU_32010L0008",
+      "national_title": "BIOTSIIDISEADUS",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32010L0009",
+      "directive_iri": "estleg:EU_32010L0009",
+      "national_title": "BIOTSIIDISEADUS",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32010L0010",
+      "directive_iri": "estleg:EU_32010L0010",
+      "national_title": "BIOTSIIDISEADUS",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32010L0011",
+      "directive_iri": "estleg:EU_32010L0011",
+      "national_title": "BIOTSIIDISEADUS",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32010L0012",
+      "directive_iri": "estleg:EU_32010L0012",
+      "national_title": "Alkoholi-, tubaka-, kütuse- ja elektriaktsiisi seadus",
+      "matched_law_name": "alkoholi_tubaka_kutuse_ja_elektriaktsiisi_seadus",
+      "matched_source_act": "Alkoholi-, tubaka-, kütuse- ja elektriaktsiisi seadus",
+      "law_files": [
+        "alkoholi_tubaka_kutuse_ja_elektriaktsiisi_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32010L0013",
+      "directive_iri": "estleg:EU_32010L0013",
+      "national_title": "Meediateenuste seadus1",
+      "matched_law_name": "meediateenuste_seadus",
+      "matched_source_act": "Meediateenuste seadus",
+      "law_files": [
+        "meediateenuste_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32010L0016",
+      "directive_iri": "estleg:EU_32010L0016",
+      "national_title": "KREDIIDIASUTUSTE SEADUS1",
+      "matched_law_name": "krediidiasutuste_seadus",
+      "matched_source_act": "Krediidiasutuste seadus",
+      "law_files": [
+        "krediidiasutuste_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32010L0024",
+      "directive_iri": "estleg:EU_32010L0024",
+      "national_title": "Maksukorralduse seadus1",
+      "matched_law_name": "maksukorralduse_seadus",
+      "matched_source_act": "Maksukorralduse seadus",
+      "law_files": [
+        "maksukorralduse_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32010L0030",
+      "directive_iri": "estleg:EU_32010L0030",
+      "national_title": "Toote nõuetele vastavuse seadus",
+      "matched_law_name": "toote_nouetele_vastavuse_seadus",
+      "matched_source_act": "Toote nõuetele vastavuse seadus",
+      "law_files": [
+        "toote_nouetele_vastavuse_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32010L0036",
+      "directive_iri": "estleg:EU_32010L0036",
+      "national_title": "Meresõiduohutuse seadus1",
+      "matched_law_name": "meresoiduohutuse_seadus",
+      "matched_source_act": "Meresõiduohutuse seadus",
+      "law_files": [
+        "meresoiduohutuse_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32010L0041",
+      "directive_iri": "estleg:EU_32010L0041",
+      "national_title": "Riikliku pensionikindlustuse seadus1",
+      "matched_law_name": "riikliku_pensionikindlustuse_seadus",
+      "matched_source_act": "Riikliku pensionikindlustuse seadus",
+      "law_files": [
+        "riikliku_pensionikindlustuse_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32010L0050",
+      "directive_iri": "estleg:EU_32010L0050",
+      "national_title": "BIOTSIIDISEADUS1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32010L0051",
+      "directive_iri": "estleg:EU_32010L0051",
+      "national_title": "BIOTSIIDISEADUS1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32010L0060",
+      "directive_iri": "estleg:EU_32010L0060",
+      "national_title": "Taimede paljundamise ja sordikaitse seadus1",
+      "matched_law_name": "taimede_paljundamise_ja_sordikaitse_seadus",
+      "matched_source_act": "Taimede paljundamise ja sordikaitse seadus",
+      "law_files": [
+        "taimede_paljundamise_ja_sordikaitse_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32010L0061",
+      "directive_iri": "estleg:EU_32010L0061",
+      "national_title": "Raudteeseadus1",
+      "matched_law_name": "raudteeseadus",
+      "matched_source_act": "Raudteeseadus",
+      "law_files": [
+        "raudteeseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32010L0066",
+      "directive_iri": "estleg:EU_32010L0066",
+      "national_title": "Käibemaksuseadus",
+      "matched_law_name": "kaibemaksuseadus",
+      "matched_source_act": "Käibemaksuseadus",
+      "law_files": [
+        "kaibemaksuseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32010L0071",
+      "directive_iri": "estleg:EU_32010L0071",
+      "national_title": "BIOTSIIDISEADUS1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32010L0072",
+      "directive_iri": "estleg:EU_32010L0072",
+      "national_title": "BIOTSIIDISEADUS1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32010L0074",
+      "directive_iri": "estleg:EU_32010L0074",
+      "national_title": "BIOTSIIDISEADUS1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32010L0075",
+      "directive_iri": "estleg:EU_32010L0075",
+      "national_title": "Tööstusheite seadus1",
+      "matched_law_name": "toostusheite_seadus",
+      "matched_source_act": "Tööstusheite seadus",
+      "law_files": [
+        "toostusheite_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32010L0076",
+      "directive_iri": "estleg:EU_32010L0076",
+      "national_title": "Krediidiasutuste seadus1",
+      "matched_law_name": "krediidiasutuste_seadus",
+      "matched_source_act": "Krediidiasutuste seadus",
+      "law_files": [
+        "krediidiasutuste_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32010L0078",
+      "directive_iri": "estleg:EU_32010L0078",
+      "national_title": "Investeerimisfondide seaduse muutmise ja sellega seonduvalt teiste seaduste muutmise seadus",
+      "matched_law_name": "investeerimisfondide_seadus",
+      "matched_source_act": "Investeerimisfondide seadus",
+      "law_files": [
+        "investeerimisfondide_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32010L0080",
+      "directive_iri": "estleg:EU_32010L0080",
+      "national_title": "Strateegilise kauba seadus1",
+      "matched_law_name": "strateegilise_kauba_seadus",
+      "matched_source_act": "Strateegilise kauba seadus",
+      "law_files": [
+        "strateegilise_kauba_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32010L0088",
+      "directive_iri": "estleg:EU_32010L0088",
+      "national_title": "Käibemaksuseadus",
+      "matched_law_name": "kaibemaksuseadus",
+      "matched_source_act": "Käibemaksuseadus",
+      "law_files": [
+        "kaibemaksuseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32011L0010",
+      "directive_iri": "estleg:EU_32011L0010",
+      "national_title": "Biotsiidiseadus1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32011L0011",
+      "directive_iri": "estleg:EU_32011L0011",
+      "national_title": "Biotsiidiseadus1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32011L0012",
+      "directive_iri": "estleg:EU_32011L0012",
+      "national_title": "Biotsiidiseadus1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32011L0013",
+      "directive_iri": "estleg:EU_32011L0013",
+      "national_title": "Biotsiidiseadus1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32011L0015",
+      "directive_iri": "estleg:EU_32011L0015",
+      "national_title": "Meresõiduohutuse seadus1",
+      "matched_law_name": "meresoiduohutuse_seadus",
+      "matched_source_act": "Meresõiduohutuse seadus",
+      "law_files": [
+        "meresoiduohutuse_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32011L0016",
+      "directive_iri": "estleg:EU_32011L0016",
+      "national_title": "Maksukorralduse seadus1",
+      "matched_law_name": "maksukorralduse_seadus",
+      "matched_source_act": "Maksukorralduse seadus",
+      "law_files": [
+        "maksukorralduse_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32011L0066",
+      "directive_iri": "estleg:EU_32011L0066",
+      "national_title": "Biotsiidiseadus1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32011L0067",
+      "directive_iri": "estleg:EU_32011L0067",
+      "national_title": "Biotsiidiseadus1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32011L0069",
+      "directive_iri": "estleg:EU_32011L0069",
+      "national_title": "Biotsiidiseadus1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32011L0071",
+      "directive_iri": "estleg:EU_32011L0071",
+      "national_title": "Biotsiidiseadus1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32011L0078",
+      "directive_iri": "estleg:EU_32011L0078",
+      "national_title": "Biotsiidiseadus1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32011L0079",
+      "directive_iri": "estleg:EU_32011L0079",
+      "national_title": "Biotsiidiseadus1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32011L0080",
+      "directive_iri": "estleg:EU_32011L0080",
+      "national_title": "Biotsiidiseadus1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32011L0081",
+      "directive_iri": "estleg:EU_32011L0081",
+      "national_title": "Biotsiidiseadus1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32012L0002",
+      "directive_iri": "estleg:EU_32012L0002",
+      "national_title": "Biotsiidiseadus1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32012L0003",
+      "directive_iri": "estleg:EU_32012L0003",
+      "national_title": "Biotsiidiseadus1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32012L0014",
+      "directive_iri": "estleg:EU_32012L0014",
+      "national_title": "Biotsiidiseadus1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32012L0015",
+      "directive_iri": "estleg:EU_32012L0015",
+      "national_title": "Biotsiidiseadus1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32012L0016",
+      "directive_iri": "estleg:EU_32012L0016",
+      "national_title": "Biotsiidiseadus1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32012L0020",
+      "directive_iri": "estleg:EU_32012L0020",
+      "national_title": "Biotsiidiseadus1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32012L0022",
+      "directive_iri": "estleg:EU_32012L0022",
+      "national_title": "Biotsiidiseadus1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32012L0038",
+      "directive_iri": "estleg:EU_32012L0038",
+      "national_title": "Biotsiidiseadus1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32012L0040",
+      "directive_iri": "estleg:EU_32012L0040",
+      "national_title": "Biotsiidiseadus1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32012L0041",
+      "directive_iri": "estleg:EU_32012L0041",
+      "national_title": "Biotsiidiseadus1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32012L0042",
+      "directive_iri": "estleg:EU_32012L0042",
+      "national_title": "Biotsiidiseadus1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32012L0043",
+      "directive_iri": "estleg:EU_32012L0043",
+      "national_title": "Biotsiidiseadus1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32013L0003",
+      "directive_iri": "estleg:EU_32013L0003",
+      "national_title": "Biotsiidiseadus1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32013L0004",
+      "directive_iri": "estleg:EU_32013L0004",
+      "national_title": "Biotsiidiseadus1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32013L0005",
+      "directive_iri": "estleg:EU_32013L0005",
+      "national_title": "Biotsiidiseadus1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32013L0006",
+      "directive_iri": "estleg:EU_32013L0006",
+      "national_title": "Biotsiidiseadus1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32013L0007",
+      "directive_iri": "estleg:EU_32013L0007",
+      "national_title": "Biotsiidiseadus1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32013L0019",
+      "directive_iri": "estleg:EU_32013L0019",
+      "national_title": "Kohaliku omavalitsuse volikogu valimise seadus",
+      "matched_law_name": "kohaliku_omavalitsuse",
+      "matched_source_act": "Kohaliku omavalitsuse korralduse seadus",
+      "law_files": [
+        "kohaliku_omavalitsuse_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32013L0023",
+      "directive_iri": "estleg:EU_32013L0023",
+      "national_title": "Krediidiasutuste seadus1",
+      "matched_law_name": "krediidiasutuste_seadus",
+      "matched_source_act": "Krediidiasutuste seadus",
+      "law_files": [
+        "krediidiasutuste_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32013L0032",
+      "directive_iri": "estleg:EU_32013L0032",
+      "national_title": "Välismaalasele rahvusvahelise kaitse andmise seadus",
+      "matched_law_name": "valismaalasele_rahvusvahelise_kaitse_andmise_seadus",
+      "matched_source_act": "Välismaalasele rahvusvahelise kaitse andmise seadus",
+      "law_files": [
+        "valismaalasele_rahvusvahelise_kaitse_andmise_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32013L0033",
+      "directive_iri": "estleg:EU_32013L0033",
+      "national_title": "Välismaalasele rahvusvahelise kaitse andmise seadus",
+      "matched_law_name": "valismaalasele_rahvusvahelise_kaitse_andmise_seadus",
+      "matched_source_act": "Välismaalasele rahvusvahelise kaitse andmise seadus",
+      "law_files": [
+        "valismaalasele_rahvusvahelise_kaitse_andmise_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32013L0041",
+      "directive_iri": "estleg:EU_32013L0041",
+      "national_title": "Biotsiidiseadus1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32013L0044",
+      "directive_iri": "estleg:EU_32013L0044",
+      "national_title": "Biotsiidiseadus1",
+      "matched_law_name": "biotsiidiseadus",
+      "matched_source_act": "Biotsiidiseadus",
+      "law_files": [
+        "biotsiidiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32013L0051",
+      "directive_iri": "estleg:EU_32013L0051",
+      "national_title": "Rahvatervise seadus",
+      "matched_law_name": "rahvatervise_seadus",
+      "matched_source_act": "Rahvatervise seadus",
+      "law_files": [
+        "rahvatervise_seadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32014L0062",
+      "directive_iri": "estleg:EU_32014L0062",
+      "national_title": "Kohtuekspertiisiseadus",
+      "matched_law_name": "kohtuekspertiisiseadus",
+      "matched_source_act": "Kohtuekspertiisiseadus",
+      "law_files": [
+        "kohtuekspertiisiseadus_peep.json"
+      ]
+    },
+    {
+      "directive_celex": "32015L2392",
+      "directive_iri": "estleg:EU_32015L2392",
+      "national_title": "Väärtpaberituru seaduse ja Finantsinspektsiooni seaduse muutmise seadus",
+      "matched_law_name": "finantsinspektsiooni_seadus",
+      "matched_source_act": "Finantsinspektsiooni seadus",
+      "law_files": [
+        "finantsinspektsiooni_seadus_peep.json"
+      ]
+    }
+  ],
+  "unmatched_sample": [
+    "Prokuratuuri taotlusel kaaluka avaliku huvi korral tähtajalise elamisloa andmise menetluse algatamiseks esitatavate andmete ja taotlusele lisatavate dokumentide loetelu ning prokuratuuri taotluse vorm",
+    "Ohtlike kemikaalide identifitseerimise, klassifitseerimise, pakendamise ja märgistamise nõuded ning kord1",
+    "EM estime MNE non nécessaire - MS does not consider NEM necessary.",
+    "Elamislubade ja töölubade registri pidamise põhimäärus",
+    "Välisriigi lippu kandvate laevade kontrollimise kord1",
+    "Ohutustunnistuse väljaandmise, muutmise ja kehtivuse pikendamise kord ning ohutustunnistuse vormid",
+    "Perekonnaseisukannete tegemise ning väljatrüki edastamise ja säilitamise kord",
+    "Nõuded kodumajapidamises kasutamiseks mõeldud elektriahju energiamärgistusele, tootekirjeldusele ja tehnilisele dokumentatsioonile1",
+    "Väljasõidukohustuse sundtäitmise korraldamine",
+    "Üldgeoloogilise uurimistöö loa ja uuringuloa taotluse vorm, üldgeoloogilise uurimistöö loa ning uuringuloa taotlusele, seletuskirjale ja graafilisele osale esitatavad täpsustatud nõuded, üldgeoloogilise uurimistöö loa ning uuringuloa andmise menetlustoimingute tähtajad ja üldgeoloogilise uurimistöö loa ning uuringuloa vorm",
+    "EM estime MNE non nécessaire - MS does not consider NEM necessary.",
+    "Strateegilise kauba komisjoni moodustamine ja töökord",
+    "Ravimi müügiloa taotluse liigid ja vorminõuded, täiendava dokumentatsiooni loetelu, täiendavale dokumentatsioonile esitatavad nõuded, taotluse erialase hindamise tasu suurus taotluse eri liikide kaupa ning tasu arvestamise ja tasumise kord*",
+    "Ravimi müügiloa taotluse liigid ja vorminõuded, täiendava dokumentatsiooni loetelu, täiendavale dokumentatsioonile esitatavad nõuded, taotluse erialase hindamise tasu suurus taotluse eri liikide kaupa ning tasu arvestamise ja tasumise kord*",
+    "Aadressiandmete süsteem",
+    "Tava- ja kiirraudteesüsteemi koostalitluse tehniliste kirjelduste kohaldamise kord1",
+    "Elanikkonnale ja loodusele ohtlike kemikaalide käitlemise piirangud",
+    "Elanikkonnale ja loodusele ohtlike kemikaalide käitlemise piirangud",
+    "Elanikkonnale ja loodusele ohtlike kemikaalide käitlemise piirangud",
+    "Elanikkonnale ja loodusele ohtlike kemikaalide käitlemise piirangud",
+    "Elanikkonnale ja loodusele ohtlike kemikaalide käitlemise piirangud",
+    "Elanikkonnale ja loodusele ohtlike kemikaalide käitlemise piirangud",
+    "Elanikkonnale ja loodusele ohtlike kemikaalide käitlemise piirangud",
+    "Elanikkonnale ja loodusele ohtlike kemikaalide käitlemise piirangud",
+    "Elanikkonnale ja loodusele ohtlike kemikaalide käitlemise piirangud",
+    "Elanikkonnale ja loodusele ohtlike kemikaalide käitlemise piirangud",
+    "Elanikkonnale ja loodusele ohtlike kemikaalide käitlemise piirangud",
+    "Elanikkonnale ja loodusele ohtlike kemikaalide käitlemise piirangud",
+    "Elanikkonnale ja loodusele ohtlike kemikaalide käitlemise piirangud",
+    "Elanikkonnale ja loodusele ohtlike kemikaalide käitlemise piirangud",
+    "Elanikkonnale ja loodusele ohtlike kemikaalide käitlemise piirangud",
+    "Elanikkonnale ja loodusele ohtlike kemikaalide käitlemise piirangud",
+    "Elanikkonnale ja loodusele ohtlike kemikaalide käitlemise piirangud",
+    "Elanikkonnale ja loodusele ohtlike kemikaalide käitlemise piirangud",
+    "Elanikkonnale ja loodusele ohtlike kemikaalide käitlemise piirangud",
+    "Elanikkonnale ja loodusele ohtlike kemikaalide käitlemise piirangud",
+    "Elanikkonnale ja loodusele ohtlike kemikaalide käitlemise piirangud",
+    "Elanikkonnale ja loodusele ohtlike kemikaalide käitlemise piirangud",
+    "Elanikkonnale ja loodusele ohtlike kemikaalide käitlemise piirangud",
+    "Elanikkonnale ja loodusele ohtlike kemikaalide käitlemise piirangud",
+    "Elanikkonnale ja loodusele ohtlike kemikaalide käitlemise piirangud",
+    "Elanikkonnale ja loodusele ohtlike kemikaalide käitlemise piirangud",
+    "Elanikkonnale ja loodusele ohtlike kemikaalide käitlemise piirangud",
+    "Elanikkonnale ja loodusele ohtlike kemikaalide käitlemise piirangud",
+    "Elanikkonnale ja loodusele ohtlike kemikaalide käitlemise piirangud",
+    "Elanikkonnale ja loodusele ohtlike kemikaalide käitlemise piirangud",
+    "Elanikkonnale ja loodusele ohtlike kemikaalide käitlemise piirangud",
+    "Elanikkonnale ja loodusele ohtlike kemikaalide käitlemise piirangud",
+    "Elanikkonnale ja loodusele ohtlike kemikaalide käitlemise piirangud",
+    "Elanikkonnale ja loodusele ohtlike kemikaalide käitlemise piirangud"
+  ],
   "missing_directives_sample": [],
   "missing_law_iris_sample": []
 }

--- a/krr_outputs/tsiviilseadustiku_uldosa_seadus_osa2_peep.json
+++ b/krr_outputs/tsiviilseadustiku_uldosa_seadus_osa2_peep.json
@@ -30,7 +30,16 @@
         {
           "@id": "http://eurovoc.europa.eu/3611"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32007L0036"
+        },
+        {
+          "@id": "estleg:EU_32009L0052"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_TsÜS_osa2",

--- a/krr_outputs/tsiviilseadustiku_uldosa_seadus_osa4_peep.json
+++ b/krr_outputs/tsiviilseadustiku_uldosa_seadus_osa4_peep.json
@@ -30,7 +30,16 @@
         {
           "@id": "http://eurovoc.europa.eu/3606"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32007L0036"
+        },
+        {
+          "@id": "estleg:EU_32009L0052"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_TsÜS_osa4",

--- a/krr_outputs/tsiviilseadustiku_uldosa_seadus_osa7_peep.json
+++ b/krr_outputs/tsiviilseadustiku_uldosa_seadus_osa7_peep.json
@@ -47,7 +47,16 @@
         {
           "@id": "http://eurovoc.europa.eu/2841"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32007L0036"
+        },
+        {
+          "@id": "estleg:EU_32009L0052"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_TsÜS_osa7",

--- a/krr_outputs/tubaka_seadus_peep.json
+++ b/krr_outputs/tubaka_seadus_peep.json
@@ -37,7 +37,13 @@
         {
           "@id": "http://eurovoc.europa.eu/5216"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32003L0033"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_tubakaseadus",

--- a/krr_outputs/ulikooliseadus_peep.json
+++ b/krr_outputs/ulikooliseadus_peep.json
@@ -44,7 +44,13 @@
         {
           "@id": "http://eurovoc.europa.eu/2446"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32005L0036"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_ÜKS",

--- a/krr_outputs/vaartpaberituru_seadus_peep.json
+++ b/krr_outputs/vaartpaberituru_seadus_peep.json
@@ -106,7 +106,22 @@
         {
           "@id": "http://eurovoc.europa.eu/2441"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32007L0044"
+        },
+        {
+          "@id": "estleg:EU_32009L0109"
+        },
+        {
+          "@id": "estleg:EU_32009L0044"
+        },
+        {
+          "@id": "estleg:EU_32009L0111"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_VPTS",

--- a/krr_outputs/vabariigi_valitsuse_seadus_peep.json
+++ b/krr_outputs/vabariigi_valitsuse_seadus_peep.json
@@ -199,7 +199,16 @@
         {
           "@id": "http://eurovoc.europa.eu/1221"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32009L0028"
+        },
+        {
+          "@id": "estleg:EU_32004L0049"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_VABARI",

--- a/krr_outputs/valismaalasele_rahvusvahelise_kaitse_andmise_seadus_peep.json
+++ b/krr_outputs/valismaalasele_rahvusvahelise_kaitse_andmise_seadus_peep.json
@@ -73,7 +73,16 @@
         {
           "@id": "http://eurovoc.europa.eu/2431"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32013L0032"
+        },
+        {
+          "@id": "estleg:EU_32013L0033"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_VRKS",

--- a/krr_outputs/valismaalaste_seadus_peep.json
+++ b/krr_outputs/valismaalaste_seadus_peep.json
@@ -190,7 +190,16 @@
         {
           "@id": "http://eurovoc.europa.eu/5636"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32009L0050"
+        },
+        {
+          "@id": "estleg:EU_32009L0052"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_VALISM",

--- a/krr_outputs/valisohu_kaitse_seadus_peep.json
+++ b/krr_outputs/valisohu_kaitse_seadus_peep.json
@@ -85,7 +85,22 @@
         {
           "@id": "http://eurovoc.europa.eu/5631"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32009L0031"
+        },
+        {
+          "@id": "estleg:EU_32008L0101"
+        },
+        {
+          "@id": "estleg:EU_32009L0029"
+        },
+        {
+          "@id": "estleg:EU_32008L0050"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_VÕKS",

--- a/krr_outputs/valjasoidukohustuse_ja_sissesoidukeelu_seadus_peep.json
+++ b/krr_outputs/valjasoidukohustuse_ja_sissesoidukeelu_seadus_peep.json
@@ -55,7 +55,16 @@
         {
           "@id": "http://eurovoc.europa.eu/0816"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32008L0115"
+        },
+        {
+          "@id": "estleg:EU_32003L0110"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_VSS",

--- a/krr_outputs/veeseadus_peep.json
+++ b/krr_outputs/veeseadus_peep.json
@@ -81,7 +81,25 @@
         {
           "@id": "http://eurovoc.europa.eu/2441"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32000L0060"
+        },
+        {
+          "@id": "estleg:EU_32009L0123"
+        },
+        {
+          "@id": "estleg:EU_32008L0056"
+        },
+        {
+          "@id": "estleg:EU_32009L0090"
+        },
+        {
+          "@id": "estleg:EU_32009L0031"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_VEE",

--- a/krr_outputs/veterinaarkorralduse_seadus_peep.json
+++ b/krr_outputs/veterinaarkorralduse_seadus_peep.json
@@ -46,7 +46,13 @@
         {
           "@id": "http://eurovoc.europa.eu/2431"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32005L0036"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_VetKS",

--- a/krr_outputs/volaigusseadus_osa11_peep.json
+++ b/krr_outputs/volaigusseadus_osa11_peep.json
@@ -24,7 +24,37 @@
         {
           "@id": "http://eurovoc.europa.eu/2431"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32009L0052"
+        },
+        {
+          "@id": "estleg:EU_31990L0314"
+        },
+        {
+          "@id": "estleg:EU_31999L0044"
+        },
+        {
+          "@id": "estleg:EU_32002L0065"
+        },
+        {
+          "@id": "estleg:EU_31997L0007"
+        },
+        {
+          "@id": "estleg:EU_31993L0013"
+        },
+        {
+          "@id": "estleg:EU_32008L0122"
+        },
+        {
+          "@id": "estleg:EU_32008L0048"
+        },
+        {
+          "@id": "estleg:EU_32009L0044"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalPart",

--- a/krr_outputs/volaigusseadus_osa12_peep.json
+++ b/krr_outputs/volaigusseadus_osa12_peep.json
@@ -28,7 +28,37 @@
         {
           "@id": "http://eurovoc.europa.eu/2431"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32009L0052"
+        },
+        {
+          "@id": "estleg:EU_31990L0314"
+        },
+        {
+          "@id": "estleg:EU_31999L0044"
+        },
+        {
+          "@id": "estleg:EU_32002L0065"
+        },
+        {
+          "@id": "estleg:EU_31997L0007"
+        },
+        {
+          "@id": "estleg:EU_31993L0013"
+        },
+        {
+          "@id": "estleg:EU_32008L0122"
+        },
+        {
+          "@id": "estleg:EU_32008L0048"
+        },
+        {
+          "@id": "estleg:EU_32009L0044"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalPart",

--- a/krr_outputs/volaigusseadus_osa13_peep.json
+++ b/krr_outputs/volaigusseadus_osa13_peep.json
@@ -30,7 +30,37 @@
         {
           "@id": "http://eurovoc.europa.eu/2806"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32009L0052"
+        },
+        {
+          "@id": "estleg:EU_31990L0314"
+        },
+        {
+          "@id": "estleg:EU_31999L0044"
+        },
+        {
+          "@id": "estleg:EU_32002L0065"
+        },
+        {
+          "@id": "estleg:EU_31997L0007"
+        },
+        {
+          "@id": "estleg:EU_31993L0013"
+        },
+        {
+          "@id": "estleg:EU_32008L0122"
+        },
+        {
+          "@id": "estleg:EU_32008L0048"
+        },
+        {
+          "@id": "estleg:EU_32009L0044"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalPart",

--- a/krr_outputs/volaigusseadus_osa1_peep.json
+++ b/krr_outputs/volaigusseadus_osa1_peep.json
@@ -35,7 +35,37 @@
         {
           "@id": "http://eurovoc.europa.eu/2451"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32009L0052"
+        },
+        {
+          "@id": "estleg:EU_31990L0314"
+        },
+        {
+          "@id": "estleg:EU_31999L0044"
+        },
+        {
+          "@id": "estleg:EU_32002L0065"
+        },
+        {
+          "@id": "estleg:EU_31997L0007"
+        },
+        {
+          "@id": "estleg:EU_31993L0013"
+        },
+        {
+          "@id": "estleg:EU_32008L0122"
+        },
+        {
+          "@id": "estleg:EU_32008L0048"
+        },
+        {
+          "@id": "estleg:EU_32009L0044"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_VOS_Osa7_osa1",

--- a/krr_outputs/volaigusseadus_osa3_peep.json
+++ b/krr_outputs/volaigusseadus_osa3_peep.json
@@ -26,7 +26,37 @@
         {
           "@id": "http://eurovoc.europa.eu/3611"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32009L0052"
+        },
+        {
+          "@id": "estleg:EU_31990L0314"
+        },
+        {
+          "@id": "estleg:EU_31999L0044"
+        },
+        {
+          "@id": "estleg:EU_32002L0065"
+        },
+        {
+          "@id": "estleg:EU_31997L0007"
+        },
+        {
+          "@id": "estleg:EU_31993L0013"
+        },
+        {
+          "@id": "estleg:EU_32008L0122"
+        },
+        {
+          "@id": "estleg:EU_32008L0048"
+        },
+        {
+          "@id": "estleg:EU_32009L0044"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_VOS_Osa7_osa3",

--- a/krr_outputs/volaigusseadus_osa4_peep.json
+++ b/krr_outputs/volaigusseadus_osa4_peep.json
@@ -23,7 +23,37 @@
         {
           "@id": "http://eurovoc.europa.eu/2431"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32009L0052"
+        },
+        {
+          "@id": "estleg:EU_31990L0314"
+        },
+        {
+          "@id": "estleg:EU_31999L0044"
+        },
+        {
+          "@id": "estleg:EU_32002L0065"
+        },
+        {
+          "@id": "estleg:EU_31997L0007"
+        },
+        {
+          "@id": "estleg:EU_31993L0013"
+        },
+        {
+          "@id": "estleg:EU_32008L0122"
+        },
+        {
+          "@id": "estleg:EU_32008L0048"
+        },
+        {
+          "@id": "estleg:EU_32009L0044"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_VOS_Osa7_osa4",

--- a/krr_outputs/volaigusseadus_osa5_peep.json
+++ b/krr_outputs/volaigusseadus_osa5_peep.json
@@ -30,7 +30,37 @@
         {
           "@id": "http://eurovoc.europa.eu/1011"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32009L0052"
+        },
+        {
+          "@id": "estleg:EU_31990L0314"
+        },
+        {
+          "@id": "estleg:EU_31999L0044"
+        },
+        {
+          "@id": "estleg:EU_32002L0065"
+        },
+        {
+          "@id": "estleg:EU_31997L0007"
+        },
+        {
+          "@id": "estleg:EU_31993L0013"
+        },
+        {
+          "@id": "estleg:EU_32008L0122"
+        },
+        {
+          "@id": "estleg:EU_32008L0048"
+        },
+        {
+          "@id": "estleg:EU_32009L0044"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalPart",

--- a/krr_outputs/volaigusseadus_osa7_peep.json
+++ b/krr_outputs/volaigusseadus_osa7_peep.json
@@ -62,7 +62,37 @@
         {
           "@id": "http://eurovoc.europa.eu/2806"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32009L0052"
+        },
+        {
+          "@id": "estleg:EU_31990L0314"
+        },
+        {
+          "@id": "estleg:EU_31999L0044"
+        },
+        {
+          "@id": "estleg:EU_32002L0065"
+        },
+        {
+          "@id": "estleg:EU_31997L0007"
+        },
+        {
+          "@id": "estleg:EU_31993L0013"
+        },
+        {
+          "@id": "estleg:EU_32008L0122"
+        },
+        {
+          "@id": "estleg:EU_32008L0048"
+        },
+        {
+          "@id": "estleg:EU_32009L0044"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_vos_osa7",

--- a/krr_outputs/volaigusseadus_osa8_peep.json
+++ b/krr_outputs/volaigusseadus_osa8_peep.json
@@ -36,7 +36,37 @@
         {
           "@id": "http://eurovoc.europa.eu/4421"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32009L0052"
+        },
+        {
+          "@id": "estleg:EU_31990L0314"
+        },
+        {
+          "@id": "estleg:EU_31999L0044"
+        },
+        {
+          "@id": "estleg:EU_32002L0065"
+        },
+        {
+          "@id": "estleg:EU_31997L0007"
+        },
+        {
+          "@id": "estleg:EU_31993L0013"
+        },
+        {
+          "@id": "estleg:EU_32008L0122"
+        },
+        {
+          "@id": "estleg:EU_32008L0048"
+        },
+        {
+          "@id": "estleg:EU_32009L0044"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalPart",

--- a/krr_outputs/volaigusseadus_osa9_peep.json
+++ b/krr_outputs/volaigusseadus_osa9_peep.json
@@ -36,7 +36,37 @@
         {
           "@id": "http://eurovoc.europa.eu/3611"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32009L0052"
+        },
+        {
+          "@id": "estleg:EU_31990L0314"
+        },
+        {
+          "@id": "estleg:EU_31999L0044"
+        },
+        {
+          "@id": "estleg:EU_32002L0065"
+        },
+        {
+          "@id": "estleg:EU_31997L0007"
+        },
+        {
+          "@id": "estleg:EU_31993L0013"
+        },
+        {
+          "@id": "estleg:EU_32008L0122"
+        },
+        {
+          "@id": "estleg:EU_32008L0048"
+        },
+        {
+          "@id": "estleg:EU_32009L0044"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalPart",

--- a/krr_outputs/vordse_kohtlemise_seadus_peep.json
+++ b/krr_outputs/vordse_kohtlemise_seadus_peep.json
@@ -76,7 +76,19 @@
         {
           "@id": "http://eurovoc.europa.eu/2421"
         }
-      ]
+      ],
+      "estleg:transposesDirective": [
+        {
+          "@id": "estleg:EU_32004L0113"
+        },
+        {
+          "@id": "estleg:EU_32002L0073"
+        },
+        {
+          "@id": "estleg:EU_32006L0054"
+        }
+      ],
+      "estleg:transpositionStatus": "unknown"
     },
     {
       "@id": "estleg:LegalProvision_VõrdKS",

--- a/scripts/generate_eu_court_decisions.py
+++ b/scripts/generate_eu_court_decisions.py
@@ -193,15 +193,38 @@ def truncate_label(title: str, max_len: int = 500) -> str:
 
 
 def sparql_query(query: str) -> list[dict]:
-    """Execute a SPARQL query and return bindings."""
-    resp = requests.get(
+    """Execute a SPARQL query and return bindings.
+
+    We POST the query (``application/x-www-form-urlencoded``) instead of
+    GETting it. The Publications Office Virtuoso endpoint answers GET for
+    non-trivial queries with ``HTTP 202 Accepted`` and an *empty* body;
+    ``raise_for_status()`` does not raise on 2xx, so a GET helper silently
+    returns ``[]`` (root cause of #129/#96). POST returns ``200`` +
+    ``application/sparql-results+json``. We still guard against a 202 /
+    non-JSON body so the retry layer reacts if POST ever misbehaves too.
+    """
+    resp = requests.post(
         SPARQL_ENDPOINT,
-        params={"query": query},
-        headers={"Accept": "application/sparql-results+json"},
+        data={"query": query},
+        headers={
+            "Accept": "application/sparql-results+json",
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
         timeout=120,
     )
     resp.raise_for_status()
-    data = resp.json()
+    if resp.status_code == 202:
+        raise RuntimeError(
+            f"SPARQL endpoint returned HTTP 202 (empty body) — "
+            f"endpoint unhealthy or rate-limiting: {SPARQL_ENDPOINT}"
+        )
+    try:
+        data = resp.json()
+    except ValueError as exc:
+        raise RuntimeError(
+            f"SPARQL endpoint returned a non-JSON body "
+            f"(status {resp.status_code}): {exc}"
+        ) from exc
     return data.get("results", {}).get("bindings", [])
 
 

--- a/scripts/generate_eu_legislation.py
+++ b/scripts/generate_eu_legislation.py
@@ -97,15 +97,38 @@ def sanitize_celex(celex: str) -> str:
 
 
 def sparql_query(query: str) -> list[dict]:
-    """Execute a SPARQL query and return bindings."""
-    resp = requests.get(
+    """Execute a SPARQL query and return bindings.
+
+    We POST the query (``application/x-www-form-urlencoded``) instead of
+    GETting it. The Publications Office Virtuoso endpoint answers GET for
+    non-trivial queries with ``HTTP 202 Accepted`` and an *empty* body;
+    ``raise_for_status()`` does not raise on 2xx, so a GET helper silently
+    returns ``[]`` (root cause of #129/#96). POST returns ``200`` +
+    ``application/sparql-results+json``. We still guard against a 202 /
+    non-JSON body so the retry layer reacts if POST ever misbehaves too.
+    """
+    resp = requests.post(
         SPARQL_ENDPOINT,
-        params={"query": query},
-        headers={"Accept": "application/sparql-results+json"},
+        data={"query": query},
+        headers={
+            "Accept": "application/sparql-results+json",
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
         timeout=120,
     )
     resp.raise_for_status()
-    data = resp.json()
+    if resp.status_code == 202:
+        raise RuntimeError(
+            f"SPARQL endpoint returned HTTP 202 (empty body) — "
+            f"endpoint unhealthy or rate-limiting: {SPARQL_ENDPOINT}"
+        )
+    try:
+        data = resp.json()
+    except ValueError as exc:
+        raise RuntimeError(
+            f"SPARQL endpoint returned a non-JSON body "
+            f"(status {resp.status_code}): {exc}"
+        ) from exc
     return data.get("results", {}).get("bindings", [])
 
 
@@ -153,10 +176,14 @@ def fetch_legislation_type(
     partial = False
 
     while True:
+        # ``cdm:directive_date_transposition`` only exists on directive
+        # works; including it as an OPTIONAL for the other types is a
+        # no-op (it simply never binds). It is the transposition deadline
+        # surfaced as ``estleg:transpositionDeadline`` (#96).
         query = f"""
 PREFIX cdm: <http://publications.europa.eu/ontology/cdm#>
 
-SELECT DISTINCT ?work ?celex ?title ?date ?inforce ?eli ?author WHERE {{
+SELECT DISTINCT ?work ?celex ?title ?date ?inforce ?eli ?author ?deadline WHERE {{
   ?work a {cdm_class} .
   ?work cdm:resource_legal_id_celex ?celex .
   ?exp cdm:expression_belongs_to_work ?work .
@@ -166,6 +193,7 @@ SELECT DISTINCT ?work ?celex ?title ?date ?inforce ?eli ?author WHERE {{
   OPTIONAL {{ ?work cdm:resource_legal_in-force ?inforce }}
   OPTIONAL {{ ?work cdm:resource_legal_eli ?eli }}
   OPTIONAL {{ ?work cdm:work_created_by_agent ?author }}
+  OPTIONAL {{ ?work cdm:directive_date_transposition ?deadline }}
 }} ORDER BY ?work LIMIT {PAGE_SIZE} OFFSET {offset}
 """
         print(f"    Fetching offset {offset}...")
@@ -197,6 +225,17 @@ SELECT DISTINCT ?work ?celex ?title ?date ?inforce ?eli ?author WHERE {{
                             if author_code not in item["authors"]:
                                 item["authors"].append(author_code)
                             break
+                # A directive may carry several ``directive_date_transposition``
+                # values (corrigenda). Keep the earliest so the node has a
+                # single deterministic deadline.
+                deadline = b.get("deadline", {}).get("value", "")
+                if deadline:
+                    for item in all_items:
+                        if item["celex"] == celex:
+                            cur = item.get("transposition_deadline", "")
+                            if not cur or deadline < cur:
+                                item["transposition_deadline"] = deadline
+                            break
                 continue
 
             seen_celex.add(celex)
@@ -211,6 +250,7 @@ SELECT DISTINCT ?work ?celex ?title ?date ?inforce ?eli ?author WHERE {{
                 "in_force": b.get("inforce", {}).get("value", ""),
                 "eli": b.get("eli", {}).get("value", ""),
                 "authors": [author_code] if author_code else [],
+                "transposition_deadline": b.get("deadline", {}).get("value", ""),
             })
 
         if len(bindings) < PAGE_SIZE:
@@ -322,6 +362,10 @@ def generate_schema_nodes() -> list[dict]:
             "rdfs:range": {"@id": "xsd:date"},
             "rdfs:comment": {"@value": "Date of the legal act.", "@language": "en"},
         },
+        # NOTE: ``estleg:transpositionDeadline`` (#96) is a corpus-wide
+        # reusable property declared in ``controlled_vocabulary.jsonld`` — not
+        # here — so it is defined exactly once (re-declaring it in this
+        # subcorpus schema would trip ``validate_all.validate_id_uniqueness``).
         {
             "@id": "estleg:inForce",
             "@type": ["owl:DatatypeProperty"],
@@ -385,6 +429,14 @@ def legislation_to_node(item: dict, type_id: str) -> dict:
     # Date
     if item.get("date"):
         node["estleg:documentDate"] = {"@value": item["date"], "@type": "xsd:date"}
+
+    # Transposition deadline (directives only; many directives — and all
+    # regulations/decisions — have none, so emit only when present, #96).
+    if item.get("transposition_deadline"):
+        node["estleg:transpositionDeadline"] = {
+            "@value": item["transposition_deadline"],
+            "@type": "xsd:date",
+        }
 
     # In-force status
     if item.get("in_force"):

--- a/scripts/generate_harmonisation_links.py
+++ b/scripts/generate_harmonisation_links.py
@@ -90,15 +90,38 @@ def sanitize_celex(celex: str) -> str:
 
 
 def sparql_query(query: str) -> list[dict]:
-    """Execute a SPARQL query and return bindings."""
-    resp = requests.get(
+    """Execute a SPARQL query and return bindings.
+
+    We POST the query (``application/x-www-form-urlencoded``) instead of
+    GETting it. The Publications Office Virtuoso endpoint answers GET for
+    non-trivial queries with ``HTTP 202 Accepted`` and an *empty* body;
+    ``raise_for_status()`` does not raise on 2xx, so a GET helper silently
+    returns ``[]`` (root cause of #129/#96). POST returns ``200`` +
+    ``application/sparql-results+json``. We still guard against a 202 /
+    non-JSON body so the retry layer reacts if POST ever misbehaves too.
+    """
+    resp = requests.post(
         SPARQL_ENDPOINT,
-        params={"query": query},
-        headers={"Accept": "application/sparql-results+json"},
+        data={"query": query},
+        headers={
+            "Accept": "application/sparql-results+json",
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
         timeout=120,
     )
     resp.raise_for_status()
-    data = resp.json()
+    if resp.status_code == 202:
+        raise RuntimeError(
+            f"SPARQL endpoint returned HTTP 202 (empty body) — "
+            f"endpoint unhealthy or rate-limiting: {SPARQL_ENDPOINT}"
+        )
+    try:
+        data = resp.json()
+    except ValueError as exc:
+        raise RuntimeError(
+            f"SPARQL endpoint returned a non-JSON body "
+            f"(status {resp.status_code}): {exc}"
+        ) from exc
     return data.get("results", {}).get("bindings", [])
 
 

--- a/scripts/generate_transposition_mapping.py
+++ b/scripts/generate_transposition_mapping.py
@@ -66,10 +66,21 @@ def sanitize_celex(celex: str) -> str:
 
 
 def normalize_text(text: str) -> str:
-    """Normalize text for fuzzy matching: lowercase, strip diacritics, collapse whitespace."""
+    """Normalize text for fuzzy matching.
+
+    Lowercase; NFKD-decompose and *drop* combining marks so Estonian
+    diacritics collapse the same way the filename-derived law names do
+    (``õ``→``o``, ``ä``→``a`` …); strip a trailing run of "consolidation"
+    digits that EUR-Lex appends to NIM titles (``"AUDIITORTEGEVUSE
+    SEADUS1"`` → ``audiitortegevuse seadus``); collapse whitespace.
+    """
     text = text.lower().strip()
-    # Normalize unicode
+    # Decompose and drop combining marks (diacritics) — keeps matching
+    # consistent with the underscore→space filename-derived index keys.
     text = unicodedata.normalize("NFKD", text)
+    text = "".join(ch for ch in text if not unicodedata.combining(ch))
+    # Drop a trailing consolidation digit run (``seadus1``, ``seadus2`` …).
+    text = re.sub(r"\d+$", "", text).strip()
     # Collapse whitespace
     text = re.sub(r"\s+", " ", text)
     return text
@@ -84,7 +95,9 @@ def extract_law_name(title: str) -> str | None:
       - "Isikuandmete kaitse seadus"
       - Things ending in "seadus", "seadustik", "määrus"
     """
-    title_norm = title.strip()
+    # Strip a trailing consolidation digit run that EUR-Lex appends to
+    # some NIM titles (``"Tubakaseadus1"`` → ``"Tubakaseadus"``).
+    title_norm = re.sub(r"\d+$", "", title.strip()).strip()
 
     # Try to find explicit law name patterns
     # Pattern: title IS the law name (short titles)
@@ -100,15 +113,40 @@ def extract_law_name(title: str) -> str | None:
 
 
 def sparql_query(query: str) -> list[dict]:
-    """Execute a SPARQL query and return bindings."""
-    resp = requests.get(
+    """Execute a SPARQL query and return bindings.
+
+    We POST the query as ``application/x-www-form-urlencoded`` rather than
+    GETting it with a ``?query=`` string. The Publications Office Virtuoso
+    endpoint (``publications.europa.eu/webapi/rdf/sparql``) answers GET
+    requests for non-trivial queries with ``HTTP 202 Accepted`` and an
+    *empty* body — and ``Response.raise_for_status()`` does NOT raise on a
+    2xx, so a GET-based helper silently returns ``[]`` (this was the real
+    cause of #129/#96). POST returns ``200`` + ``application/sparql-results+json``.
+    We still guard explicitly against a 202 / non-JSON body so the retry
+    layer can react if the endpoint ever misbehaves on POST too.
+    """
+    resp = requests.post(
         SPARQL_ENDPOINT,
-        params={"query": query},
-        headers={"Accept": "application/sparql-results+json"},
+        data={"query": query},
+        headers={
+            "Accept": "application/sparql-results+json",
+            "Content-Type": "application/x-www-form-urlencoded",
+        },
         timeout=120,
     )
     resp.raise_for_status()
-    data = resp.json()
+    if resp.status_code == 202:
+        raise RuntimeError(
+            f"SPARQL endpoint returned HTTP 202 (empty body) — "
+            f"endpoint unhealthy or rate-limiting: {SPARQL_ENDPOINT}"
+        )
+    try:
+        data = resp.json()
+    except ValueError as exc:
+        raise RuntimeError(
+            f"SPARQL endpoint returned a non-JSON body "
+            f"(status {resp.status_code}): {exc}"
+        ) from exc
     return data.get("results", {}).get("bindings", [])
 
 
@@ -139,11 +177,30 @@ def sparql_query_with_retry(
     ) from last_exc
 
 
+# Authority URI for Estonia in the Publications Office country vocabulary.
+ESTONIA_COUNTRY_URI = "http://publications.europa.eu/resource/authority/country/EST"
+
+
 def fetch_transposition_measures(
     *, allow_partial: bool = False
 ) -> tuple[list[dict], bool]:
     """
     Fetch national transposition measures for Estonia from EUR-Lex.
+
+    The CDM models a National Implementing Measure (NIM) as a ``work``
+    typed (effectively) ``cdm:measure_national_implementing`` that carries:
+      * ``cdm:measure_national_implementing_implemented_by_country`` → the
+        country authority URI (we filter for Estonia);
+      * ``cdm:measure_national_implementing_implements_directive`` → the
+        directive ``work`` URI it transposes;
+      * ``cdm:work_title`` → the (national-language) title — for Estonian
+        NIMs this is already the Estonian act title (e.g.
+        ``"TÖÖLEPINGU SEADUS"``), so no per-language expression join is
+        needed.
+    The earlier query used ``cdm:resource_legal_measures_transposition_for``
+    and required the directive to be ``a cdm:directive`` with a
+    ``"7"``-prefixed national CELEX in an EST *expression* — none of which
+    holds in CELLAR today, so it returned zero rows (#129).
 
     Returns ``(items, partial)`` where each item is a dict with
     ``celex_dir``, ``directive_uri``, ``title_nat`` and ``partial`` is
@@ -152,7 +209,7 @@ def fetch_transposition_measures(
     failures propagate as ``RuntimeError`` so the run exits non-zero
     rather than silently truncating the dataset (#129).
 
-    Note: ``ORDER BY ?national`` makes OFFSET pagination stable across
+    Note: ``ORDER BY ?nim`` makes OFFSET pagination stable across
     pages — without it EUR-Lex may reorder rows between requests and
     drop/duplicate measures (#183).
     """
@@ -164,16 +221,12 @@ def fetch_transposition_measures(
     while True:
         query = f"""
 PREFIX cdm: <http://publications.europa.eu/ontology/cdm#>
-SELECT DISTINCT ?directive ?celex_dir ?national ?title_nat WHERE {{
-  ?directive a cdm:directive .
+SELECT DISTINCT ?nim ?directive ?celex_dir ?title_nat WHERE {{
+  ?nim cdm:measure_national_implementing_implemented_by_country <{ESTONIA_COUNTRY_URI}> .
+  ?nim cdm:measure_national_implementing_implements_directive ?directive .
   ?directive cdm:resource_legal_id_celex ?celex_dir .
-  ?national cdm:resource_legal_measures_transposition_for ?directive .
-  ?national cdm:resource_legal_id_celex ?celex_nat .
-  FILTER(STRSTARTS(?celex_nat, "7"))
-  ?exp_nat cdm:expression_belongs_to_work ?national .
-  ?exp_nat cdm:expression_uses_language <http://publications.europa.eu/resource/authority/language/EST> .
-  ?exp_nat cdm:expression_title ?title_nat .
-}} ORDER BY ?national LIMIT {PAGE_SIZE} OFFSET {offset}
+  OPTIONAL {{ ?nim cdm:work_title ?title_nat }}
+}} ORDER BY ?nim LIMIT {PAGE_SIZE} OFFSET {offset}
 """
         print(f"  Fetching transposition measures, offset {offset}...")
         try:
@@ -193,6 +246,12 @@ SELECT DISTINCT ?directive ?celex_dir ?national ?title_nat WHERE {{
             title_nat = b.get("title_nat", {}).get("value", "")
             directive_uri = b.get("directive", {}).get("value", "")
 
+            if not title_nat:
+                # A NIM without a title cannot be matched to an Estonian
+                # act by name — skip it (it still counts in EUR-Lex's NIM
+                # tally but not in ours).
+                continue
+
             key = (celex_dir, title_nat)
             if key in seen:
                 continue
@@ -211,6 +270,107 @@ SELECT DISTINCT ?directive ?celex_dir ?national ?title_nat WHERE {{
         time.sleep(RATE_DELAY)
 
     return all_items, partial
+
+
+def fetch_directive_deadlines(*, allow_partial: bool = False) -> tuple[dict[str, str], bool]:
+    """Fetch the transposition deadline (``cdm:directive_date_transposition``)
+    for every directive that declares one (#96).
+
+    Returns ``({celex: "YYYY-MM-DD"}, partial)``. A directive may carry
+    several deadline values (corrigenda); we keep the earliest so the
+    resulting node has one deterministic ``estleg:transpositionDeadline``.
+    This is a single, cheap query (no pagination needed — the property is
+    sparse), so a terminal failure under ``allow_partial`` just yields an
+    empty map and ``partial=True`` (deadlines are optional, #96), while
+    without ``allow_partial`` it propagates like every other SPARQL
+    failure in this script (#129).
+    """
+    query = """
+PREFIX cdm: <http://publications.europa.eu/ontology/cdm#>
+SELECT ?celex (MIN(?d) AS ?deadline) WHERE {
+  ?work a cdm:directive .
+  ?work cdm:resource_legal_id_celex ?celex .
+  ?work cdm:directive_date_transposition ?d .
+} GROUP BY ?celex
+"""
+    print("  Fetching directive transposition deadlines...")
+    try:
+        bindings = sparql_query_with_retry(query)
+    except Exception as e:
+        if allow_partial:
+            print(f"  ERROR fetching directive deadlines (partial run): {e}")
+            return {}, True
+        raise
+
+    deadlines: dict[str, str] = {}
+    for b in bindings:
+        celex = b.get("celex", {}).get("value", "")
+        deadline = b.get("deadline", {}).get("value", "")
+        if not celex or not deadline:
+            continue
+        # The SPARQL ``MIN`` already picks the earliest; defend anyway.
+        cur = deadlines.get(celex)
+        if cur is None or deadline < cur:
+            deadlines[celex] = deadline
+    return deadlines, False
+
+
+def update_directive_deadlines(deadlines: dict[str, str]) -> int:
+    """Add ``estleg:transpositionDeadline`` (xsd:date) to directive nodes in
+    ``eurlex_directives_peep.json`` for every CELEX with a known deadline (#96).
+
+    Emits the property only when a deadline is present (it is optional).
+    Returns the count of directive nodes updated. This is the low-risk
+    path for #96 — it patches the already-generated directives peep file
+    instead of forcing a network-heavy ``generate_eu_legislation.py``
+    rerun; ``generate_eu_legislation.py`` also emits the property on a
+    full regen (see its ``OPTIONAL ?deadline`` projection).
+    """
+    directives_file = EURLEX_DIR / "eurlex_directives_peep.json"
+    if not directives_file.exists() or not deadlines:
+        return 0
+    try:
+        data = load_json(directives_file)
+    except Exception as e:
+        print(f"  ERROR loading directives file for deadlines: {e}")
+        return 0
+
+    updated = 0
+    for node in data.get("@graph", []):
+        celex = node.get("estleg:celexNumber", "")
+        deadline = deadlines.get(celex)
+        if not deadline:
+            continue
+        new_val = {"@value": deadline, "@type": "xsd:date"}
+        if node.get("estleg:transpositionDeadline") == new_val:
+            continue
+        node["estleg:transpositionDeadline"] = new_val
+        updated += 1
+
+    if updated > 0:
+        save_json(directives_file, data)
+    return updated
+
+
+def clear_directive_deadlines() -> int:
+    """Strip ``estleg:transpositionDeadline`` from every directive node in
+    ``eurlex_directives_peep.json`` (mirrors the other clear-then-rebuild
+    steps so a deadline that disappeared upstream does not linger)."""
+    directives_file = EURLEX_DIR / "eurlex_directives_peep.json"
+    if not directives_file.exists():
+        return 0
+    try:
+        data = load_json(directives_file)
+    except Exception:
+        return 0
+    cleared = 0
+    for node in data.get("@graph", []):
+        if "estleg:transpositionDeadline" in node:
+            del node["estleg:transpositionDeadline"]
+            cleared += 1
+    if cleared > 0:
+        save_json(directives_file, data)
+    return cleared
 
 
 def build_law_index(index_data: dict) -> dict[str, dict]:
@@ -358,6 +518,11 @@ def generate_schema() -> dict:
             "rdfs:domain": {"@id": "estleg:Act"},
             "rdfs:range": {"@id": "xsd:string"},
         },
+        # NOTE: ``estleg:transpositionDeadline`` (the directive's transposition
+        # deadline, #96) is intentionally NOT declared here. It is a corpus-wide
+        # reusable property and lives in ``krr_outputs/controlled_vocabulary.jsonld``;
+        # declaring it again in this per-layer schema would trip
+        # ``validate_all.validate_id_uniqueness`` (same @id in two files).
     ]
 
     return {"@context": CONTEXT, "@graph": schema_nodes}
@@ -594,6 +759,12 @@ def main():
         except Exception as e:
             print(f"  Warning: could not clear directives file: {e}")
 
+    # And clear transpositionDeadline so a deadline removed upstream
+    # does not linger on the directive node (#96).
+    cleared_deadlines = clear_directive_deadlines()
+    if cleared_deadlines:
+        print(f"  Cleared transpositionDeadline from {cleared_deadlines} directive node(s)")
+
     # --- Step 1: Load existing indexes ---
     print("\n--- Loading existing indexes ---")
 
@@ -753,6 +924,19 @@ def main():
     directives_updated = update_directive_file(directive_celex_to_law_iris)
     print(f"  Directive nodes updated: {directives_updated}")
 
+    # --- Step 6b: Add transposition deadlines to EU directive nodes (#96) ---
+    print("\n--- Adding transposition deadlines to EU directives ---")
+    deadlines, deadlines_partial = fetch_directive_deadlines(
+        allow_partial=args.allow_partial
+    )
+    if deadlines_partial:
+        was_partial = True
+    deadline_nodes_updated = update_directive_deadlines(deadlines)
+    print(
+        f"  Directive deadlines fetched: {len(deadlines)}; "
+        f"directive nodes annotated: {deadline_nodes_updated}"
+    )
+
     # --- Step 7: Generate report ---
     print("\n--- Generating transposition mapping report ---")
 
@@ -775,6 +959,8 @@ def main():
         "unique_laws": len(unique_laws),
         "law_files_updated": files_updated,
         "directive_nodes_updated": directives_updated,
+        "directive_deadlines_fetched": len(deadlines),
+        "directive_deadline_nodes_updated": deadline_nodes_updated,
         "mappings": sorted(matched_mappings, key=lambda m: m["directive_celex"]),
         "unmatched_sample": unmatched_titles[:50],
         "missing_directives_sample": missing_directives[:50],
@@ -797,6 +983,8 @@ def main():
     print(f"  Unique Estonian laws:           {len(unique_laws)}")
     print(f"  Law files updated:              {files_updated}")
     print(f"  Directive nodes updated:        {directives_updated}")
+    print(f"  Directive deadlines fetched:    {len(deadlines)}")
+    print(f"  Directive nodes w/ deadline:    {deadline_nodes_updated}")
     if was_partial:
         print("  NOTE: run was PARTIAL — re-run without --allow-partial when "
               "EUR-Lex is healthy to refresh the layer.")

--- a/shacl/estonian_legal_shapes.ttl
+++ b/shacl/estonian_legal_shapes.ttl
@@ -576,6 +576,13 @@ estleg:EULegislationShape
         sh:description "Date of the legal act" ;
     ] ;
     sh:property [
+        sh:path estleg:transpositionDeadline ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:date ;
+        sh:name "transpositionDeadline" ;
+        sh:description "Deadline for member states to transpose this EU directive into national law (directives only; optional)" ;
+    ] ;
+    sh:property [
         sh:path estleg:inForce ;
         sh:maxCount 1 ;
         sh:datatype xsd:boolean ;

--- a/tests/test_generate_eu_sources.py
+++ b/tests/test_generate_eu_sources.py
@@ -382,3 +382,152 @@ def test_harmonisation_graph0_guard_accepts_act_level_first_node(tmp_path, monke
 def test_harmonisation_graph0_guard_handles_missing_file(tmp_path, monkeypatch):
     monkeypatch.setattr(harmonisation, "KRR_DIR", tmp_path / "nonexistent")
     assert harmonisation.get_law_harmonisation_target_iri("missing.json") is None
+
+
+# ---------------------------------------------------------------------------
+# GET → POST: the Publications Office Virtuoso endpoint 202s on GET (#129/#96).
+# ---------------------------------------------------------------------------
+
+
+class _FakeResp:
+    def __init__(self, status_code=200, json_data=None):
+        self.status_code = status_code
+        self._json = (
+            json_data
+            if json_data is not None
+            else {"results": {"bindings": [{"x": {"value": "ok"}}]}}
+        )
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._json
+
+
+@pytest.mark.parametrize("module", [eurlex, curia, harmonisation])
+def test_eu_sparql_query_posts_not_gets(module, monkeypatch):
+    """Each EU generator's ``sparql_query`` must POST the query, never GET it.
+
+    The Publications Office Virtuoso endpoint answers GET for non-trivial
+    queries with HTTP 202 + an empty body; ``raise_for_status()`` does not
+    flag a 2xx, so a GET-based helper silently returns ``[]`` (#129/#96).
+    """
+    posted = {}
+
+    def fake_post(url, data=None, headers=None, timeout=None):
+        posted["url"] = url
+        posted["data"] = data
+        posted["headers"] = headers
+        return _FakeResp()
+
+    def fail_get(*_a, **_k):  # pragma: no cover - must not be reached
+        raise AssertionError(f"{module.__name__}.sparql_query must not use requests.get")
+
+    monkeypatch.setattr(module.requests, "post", fake_post)
+    monkeypatch.setattr(module.requests, "get", fail_get)
+
+    assert module.sparql_query("ASK {}") == [{"x": {"value": "ok"}}]
+    assert posted["url"] == module.SPARQL_ENDPOINT
+    assert posted["data"] == {"query": "ASK {}"}
+    assert posted["headers"]["Accept"] == "application/sparql-results+json"
+    assert "x-www-form-urlencoded" in posted["headers"]["Content-Type"]
+
+
+@pytest.mark.parametrize("module", [eurlex, curia, harmonisation])
+def test_eu_sparql_query_202_raises(module, monkeypatch):
+    """A bare HTTP 202 (empty body) must raise so the retry layer reacts."""
+    def fake_post(url, data=None, headers=None, timeout=None):
+        return _FakeResp(status_code=202, json_data={})
+
+    monkeypatch.setattr(module.requests, "post", fake_post)
+    with pytest.raises(RuntimeError, match="202"):
+        module.sparql_query("ASK {}")
+
+
+# ---------------------------------------------------------------------------
+# #96 — transposition deadline on EU directive nodes built by generate_eu_legislation.
+# ---------------------------------------------------------------------------
+
+
+def test_eurlex_directive_query_projects_deadline(monkeypatch):
+    """The legislation query carries an OPTIONAL ?deadline projection (#96)."""
+    queries: list[str] = []
+
+    def fake_query(query: str) -> list[dict]:
+        queries.append(query)
+        return []
+
+    monkeypatch.setattr(eurlex, "sparql_query", fake_query)
+    eurlex.fetch_legislation_type("cdm:directive")
+    assert "?deadline" in queries[0]
+    assert "cdm:directive_date_transposition" in queries[0]
+
+
+def test_legislation_to_node_emits_deadline_when_present():
+    node = eurlex.legislation_to_node(
+        {
+            "celex": "32011L0083",
+            "title": "Consumer Rights Directive",
+            "date": "2011-10-25",
+            "in_force": "true",
+            "eli": "",
+            "authors": [],
+            "transposition_deadline": "2013-12-13",
+        },
+        "Directive",
+    )
+    assert node["estleg:transpositionDeadline"] == {"@value": "2013-12-13", "@type": "xsd:date"}
+
+
+def test_legislation_to_node_omits_deadline_when_absent():
+    node = eurlex.legislation_to_node(
+        {
+            "celex": "32016R0679",
+            "title": "GDPR",
+            "date": "2016-04-27",
+            "in_force": "true",
+            "eli": "",
+            "authors": [],
+            "transposition_deadline": "",
+        },
+        "Regulation",
+    )
+    assert "estleg:transpositionDeadline" not in node
+
+
+def test_eurlex_schema_does_not_redeclare_transposition_deadline():
+    """estleg:transpositionDeadline (#96) is declared once, in
+    controlled_vocabulary.jsonld — re-declaring it in the eurlex subcorpus
+    schema would trip validate_all's @id-uniqueness gate."""
+    ids = {n["@id"] for n in eurlex.generate_schema_nodes()}
+    assert "estleg:transpositionDeadline" not in ids
+    # The other EU-legislation datatype props are still declared here.
+    assert "estleg:documentDate" in ids
+    assert "estleg:celexNumber" in ids
+
+
+def test_eurlex_dedup_keeps_earliest_deadline(monkeypatch):
+    """When a directive appears across rows with several deadlines, the
+    earliest is kept (corrigenda may declare later dates)."""
+    payload = [
+        {"celex": {"value": "32007L0073"}, "work": {"value": "w"}, "title": {"value": "T"},
+         "deadline": {"value": "2008-09-14"}},
+        {"celex": {"value": "32007L0073"}, "work": {"value": "w"}, "title": {"value": "T"},
+         "deadline": {"value": "2007-12-18"}},
+    ]
+    state = {"called": False}
+
+    def fake_query(_q):
+        if state["called"]:
+            return []
+        state["called"] = True
+        return payload
+
+    monkeypatch.setattr(eurlex, "sparql_query", fake_query)
+    monkeypatch.setattr(eurlex.time, "sleep", lambda _: None)
+
+    items, partial = eurlex.fetch_legislation_type("cdm:directive")
+    assert partial is False
+    assert len(items) == 1
+    assert items[0]["transposition_deadline"] == "2007-12-18"

--- a/tests/test_generate_transposition_mapping.py
+++ b/tests/test_generate_transposition_mapping.py
@@ -10,6 +10,8 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
 import generate_transposition_mapping as mod  # noqa: E402
 
+REPO_ROOT_FOR_TESTS = Path(__file__).resolve().parent.parent
+
 
 def _write_json(path: Path, payload: dict) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -234,3 +236,279 @@ def test_transposition_query_has_order_by():
 
     src = inspect.getsource(mod.fetch_transposition_measures)
     assert "ORDER BY" in src
+
+
+# ---------------------------------------------------------------------------
+# GET → POST: the Publications Office Virtuoso endpoint 202s on GET (#129/#96).
+# ---------------------------------------------------------------------------
+
+
+class _FakeResp:
+    def __init__(self, status_code=200, json_data=None, raise_on_status=False):
+        self.status_code = status_code
+        self._json = json_data if json_data is not None else {
+            "results": {"bindings": [{"x": {"value": "ok"}}]}
+        }
+        self._raise = raise_on_status
+
+    def raise_for_status(self):
+        if self._raise:
+            raise RuntimeError("HTTP error")
+
+    def json(self):
+        if self._json is _RAISE_VALUE_ERROR:
+            raise ValueError("not JSON")
+        return self._json
+
+
+_RAISE_VALUE_ERROR = object()
+
+
+def test_sparql_query_posts_not_gets(monkeypatch):
+    """``sparql_query`` must POST the query (form-encoded) — never GET it.
+
+    The Virtuoso endpoint answers GET for non-trivial queries with HTTP 202
+    + an empty body, which ``raise_for_status()`` doesn't flag, so a GET
+    helper silently returns ``[]`` (the real cause of #129/#96).
+    """
+    posted = {}
+
+    def fake_post(url, data=None, headers=None, timeout=None):
+        posted["url"] = url
+        posted["data"] = data
+        posted["headers"] = headers
+        return _FakeResp()
+
+    def fail_get(*_a, **_k):  # pragma: no cover - must not be reached
+        raise AssertionError("sparql_query must not use requests.get")
+
+    monkeypatch.setattr(mod.requests, "post", fake_post)
+    monkeypatch.setattr(mod.requests, "get", fail_get)
+
+    result = mod.sparql_query("ASK {}")
+    assert result == [{"x": {"value": "ok"}}]
+    assert posted["url"] == mod.SPARQL_ENDPOINT
+    assert posted["data"] == {"query": "ASK {}"}
+    assert posted["headers"]["Accept"] == "application/sparql-results+json"
+    assert "x-www-form-urlencoded" in posted["headers"]["Content-Type"]
+
+
+def test_sparql_query_202_triggers_retry(monkeypatch):
+    """A bare HTTP 202 (empty body) from the endpoint must raise so the
+    retry layer reacts rather than treating it as an empty result set."""
+    calls = {"n": 0}
+
+    def fake_post(url, data=None, headers=None, timeout=None):
+        calls["n"] += 1
+        return _FakeResp(status_code=202, json_data={})
+
+    monkeypatch.setattr(mod.requests, "post", fake_post)
+
+    # Direct call raises.
+    with pytest.raises(RuntimeError, match="202"):
+        mod.sparql_query("ASK {}")
+
+    # And the retry wrapper re-raises after exhausting attempts.
+    calls["n"] = 0
+    with pytest.raises(RuntimeError, match="failed after 3 attempts"):
+        mod.sparql_query_with_retry("ASK {}", retries=3, backoff=0.0)
+    assert calls["n"] == 3
+
+
+def test_sparql_query_non_json_body_raises(monkeypatch):
+    """A 200 with a non-JSON body must raise (not crash with a bare ValueError)."""
+    def fake_post(url, data=None, headers=None, timeout=None):
+        return _FakeResp(status_code=200, json_data=_RAISE_VALUE_ERROR)
+
+    monkeypatch.setattr(mod.requests, "post", fake_post)
+    with pytest.raises(RuntimeError, match="non-JSON"):
+        mod.sparql_query("ASK {}")
+
+
+# ---------------------------------------------------------------------------
+# #129 — a successful (mocked) fetch populates transposition_mapping.json and
+# satisfies validate_all.validate_transposition_mapping.
+# ---------------------------------------------------------------------------
+
+
+def test_successful_fetch_populates_mapping_and_passes_gate(tmp_path, monkeypatch):
+    """End-to-end (mocked SPARQL): a non-empty NIM fetch yields a non-empty,
+    current-shape transposition_mapping.json that validate_all accepts (#129)."""
+    krr = tmp_path / "krr_outputs"
+    eurlex = krr / "eurlex"
+    krr.mkdir()
+    eurlex.mkdir()
+
+    # One matchable Estonian law: "Tubakaseadus", file tubakaseadus_peep.json.
+    law_file = krr / "tubakaseadus_peep.json"
+    _write_json(
+        law_file,
+        {
+            "@context": mod.CONTEXT,
+            "@graph": [
+                {"@id": "estleg:TUBAKA_Map_2026", "@type": ["owl:Ontology", "estleg:Act"],
+                 "estleg:sourceAct": "Tubakaseadus"},
+            ],
+        },
+    )
+    _write_json(
+        krr / "INDEX.json",
+        {"total_laws": 1, "laws": [{"name": "tubakaseadus", "files": ["tubakaseadus_peep.json"]}]},
+    )
+    # A directive node so the CELEX resolves to a real IRI.
+    _write_json(
+        eurlex / "eurlex_directives_peep.json",
+        {
+            "@context": mod.CONTEXT,
+            "@graph": [
+                {"@id": "estleg:EU_32003L0033", "@type": ["owl:NamedIndividual", "estleg:EULegislation"],
+                 "estleg:celexNumber": "32003L0033"},
+            ],
+        },
+    )
+
+    monkeypatch.setattr(mod, "KRR_DIR", krr)
+    monkeypatch.setattr(mod, "EURLEX_DIR", eurlex)
+    monkeypatch.setattr(mod, "REPO_ROOT", tmp_path)  # for the summary's relative_to()
+    # Mocked SPARQL: NIM fetch returns one EST measure; deadline fetch returns one row.
+    monkeypatch.setattr(
+        mod, "fetch_transposition_measures",
+        lambda **_k: ([{"celex_dir": "32003L0033", "directive_uri": "http://x/dir",
+                        "title_nat": "TUBAKASEADUS1"}], False),
+    )
+    monkeypatch.setattr(
+        mod, "fetch_directive_deadlines",
+        lambda **_k: ({"32003L0033": "2004-07-31"}, False),
+    )
+    monkeypatch.setattr(sys, "argv", ["generate_transposition_mapping.py"])
+
+    rc = mod.main()
+    assert rc in (0, None)
+
+    report = json.loads((krr / "transposition_mapping.json").read_text(encoding="utf-8"))
+    assert report["documented_empty"] is False
+    assert report["total_measures_fetched"] == 1
+    assert len(report["mappings"]) == 1
+    assert report["mappings"][0]["directive_celex"] == "32003L0033"
+    assert report["mappings"][0]["matched_law_name"] == "tubakaseadus"
+    assert report["directive_deadline_nodes_updated"] == 1
+
+    # The law peep got estleg:transposesDirective pointing at the real directive IRI.
+    law_doc = json.loads(law_file.read_text(encoding="utf-8"))
+    act_node = law_doc["@graph"][0]
+    assert {"@id": "estleg:EU_32003L0033"} in act_node["estleg:transposesDirective"]
+    # The directive node got estleg:transposedBy + estleg:transpositionDeadline.
+    dir_doc = json.loads((eurlex / "eurlex_directives_peep.json").read_text(encoding="utf-8"))
+    dir_node = dir_doc["@graph"][0]
+    assert {"@id": "estleg:TUBAKA_Map_2026"} in dir_node["estleg:transposedBy"]
+    assert dir_node["estleg:transpositionDeadline"] == {"@value": "2004-07-31", "@type": "xsd:date"}
+
+    # validate_all's gate accepts the populated report (no error recorded).
+    import importlib
+    sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+    validate_all = importlib.import_module("validate_all")
+    validate_all.errors.clear()
+    validate_all.validate_transposition_mapping(krr_dir=krr)
+    assert validate_all.errors == []
+
+
+# ---------------------------------------------------------------------------
+# #96 — transposition deadline on EU directive nodes.
+# ---------------------------------------------------------------------------
+
+
+def test_update_directive_deadlines_adds_xsd_date(tmp_path, monkeypatch):
+    """Directive nodes with a known deadline get estleg:transpositionDeadline
+    (xsd:date typed); nodes without a deadline get nothing (it's optional, #96)."""
+    eurlex = tmp_path / "eurlex"
+    _write_json(
+        eurlex / "eurlex_directives_peep.json",
+        {
+            "@context": mod.CONTEXT,
+            "@graph": [
+                {"@id": "estleg:EU_32011L0083", "@type": ["estleg:EULegislation"],
+                 "estleg:celexNumber": "32011L0083"},
+                {"@id": "estleg:EU_31980L0766", "@type": ["estleg:EULegislation"],
+                 "estleg:celexNumber": "31980L0766"},
+            ],
+        },
+    )
+    monkeypatch.setattr(mod, "EURLEX_DIR", eurlex)
+
+    updated = mod.update_directive_deadlines({"32011L0083": "2013-12-13"})
+    assert updated == 1
+
+    doc = json.loads((eurlex / "eurlex_directives_peep.json").read_text(encoding="utf-8"))
+    nodes = {n["@id"]: n for n in doc["@graph"]}
+    assert nodes["estleg:EU_32011L0083"]["estleg:transpositionDeadline"] == {
+        "@value": "2013-12-13", "@type": "xsd:date",
+    }
+    # The directive without a deadline must NOT carry the property.
+    assert "estleg:transpositionDeadline" not in nodes["estleg:EU_31980L0766"]
+
+    # Idempotent re-application is a no-op.
+    assert mod.update_directive_deadlines({"32011L0083": "2013-12-13"}) == 0
+
+
+def test_clear_directive_deadlines_strips_property(tmp_path, monkeypatch):
+    eurlex = tmp_path / "eurlex"
+    _write_json(
+        eurlex / "eurlex_directives_peep.json",
+        {
+            "@context": mod.CONTEXT,
+            "@graph": [
+                {"@id": "estleg:EU_32011L0083", "@type": ["estleg:EULegislation"],
+                 "estleg:celexNumber": "32011L0083",
+                 "estleg:transpositionDeadline": {"@value": "2013-12-13", "@type": "xsd:date"}},
+            ],
+        },
+    )
+    monkeypatch.setattr(mod, "EURLEX_DIR", eurlex)
+    assert mod.clear_directive_deadlines() == 1
+    doc = json.loads((eurlex / "eurlex_directives_peep.json").read_text(encoding="utf-8"))
+    assert "estleg:transpositionDeadline" not in doc["@graph"][0]
+
+
+def test_fetch_directive_deadlines_picks_earliest(monkeypatch):
+    """When a directive has several deadline rows, the earliest wins."""
+    def fake_query(_q):
+        return [
+            {"celex": {"value": "32007L0073"}, "deadline": {"value": "2007-12-18"}},
+            {"celex": {"value": "31980L0766"}, "deadline": {"value": "1980-10-01"}},
+        ]
+
+    monkeypatch.setattr(mod, "sparql_query_with_retry", lambda q: fake_query(q))
+    deadlines, partial = mod.fetch_directive_deadlines()
+    assert partial is False
+    assert deadlines == {"32007L0073": "2007-12-18", "31980L0766": "1980-10-01"}
+
+
+def test_normalize_text_strips_marks_and_trailing_digits():
+    """``õ``→``o`` and trailing consolidation digits are dropped so NIM
+    titles match the filename-derived law-index keys."""
+    assert mod.normalize_text("AUDIITORTEGEVUSE SEADUS1") == "audiitortegevuse seadus"
+    assert mod.normalize_text("Asjaõigusseadus1") == "asjaoigusseadus"
+    assert mod.normalize_text("TUBAKASEADUS") == "tubakaseadus"
+    assert mod.normalize_text("Asjaõigusseadus") == mod.normalize_text("asjaoigusseadus")
+
+
+def test_transposition_schema_does_not_redeclare_deadline_property():
+    """estleg:transpositionDeadline (#96) is declared once, in
+    controlled_vocabulary.jsonld — NOT in this per-layer schema (declaring
+    the same @id in two files would trip validate_all's @id-uniqueness gate)."""
+    schema = mod.generate_schema()
+    ids = {n["@id"] for n in schema["@graph"]}
+    assert "estleg:transpositionDeadline" not in ids
+    # The act-level transposition props *are* still here.
+    assert "estleg:transposesDirective" in ids
+    assert "estleg:transposedBy" in ids
+
+
+def test_controlled_vocabulary_declares_transposition_deadline():
+    """The corpus-wide vocabulary declares estleg:transpositionDeadline (#96)."""
+    vocab_path = REPO_ROOT_FOR_TESTS / "krr_outputs" / "controlled_vocabulary.jsonld"
+    doc = json.loads(vocab_path.read_text(encoding="utf-8"))
+    nodes = {n.get("@id"): n for n in doc.get("@graph", []) if isinstance(n, dict)}
+    assert "estleg:transpositionDeadline" in nodes
+    assert "owl:DatatypeProperty" in nodes["estleg:transpositionDeadline"]["@type"]
+    assert nodes["estleg:transpositionDeadline"]["rdfs:range"] == {"@id": "xsd:date"}


### PR DESCRIPTION
## Summary

The long-"blocked" #129/#96 were a SPARQL-method bug: the Publications Office Virtuoso endpoint 202s on GET-with-query (empty body, which `raise_for_status()` doesn't flag) but returns proper JSON for POST. Switched `sparql_query` in all four EU scripts GET→POST (+ a 202/non-JSON guard so the retry wrapper reacts).

- **#129** — also rewrote `fetch_transposition_measures()` against the *correct* CDM National-Implementing-Measure vocabulary (the old query used `cdm:resource_legal_measures_transposition_for`, which has zero triples). Run result: 720 NIM measures → **295 law↔directive mappings** (205 directives, 99 laws); 121 law peeps got `estleg:transposesDirective`; 205 directives got `estleg:transposedBy`. `transposition_mapping.json` is non-empty / current shape — the `validate_transposition_mapping` gate accepts it.
- **#96** — `cdm:directive_date_transposition` (3,418 directives have one). Added a cheap `GROUP BY (MIN(?d))` query + `estleg:transpositionDeadline` (xsd:date) on 2,616 directive nodes; vocab term + optional SHACL property shape on `EULegislationShape`; `generate_eu_legislation.py` also projects it natively for future regens.

`combined_ontology.jsonld` regenerated. +~18 tests.

**Follow-up flagged:** `generate_harmonisation_links.py`'s parallel-transposition query still uses the old broken `cdm:resource_legal_measures_transposition_for` property → returns 0 results; needs the same NIM-vocab rewrite (separate from #96/#129).

## Test plan
- [x] `pytest tests/` — 1,227 passed, 2 skipped
- [x] `ruff check scripts/ tests/` — clean
- [x] `python3 scripts/validate_all.py` — 0 errors / 1 benign warning; Internal Reference Integrity OK; `validate_transposition_mapping` accepts the non-empty mapping
- [x] `python3 scripts/validate_seadusloome_sync.py` — SHACL PASS
- [x] `python3 scripts/shacl_validate_all.py --bucket eurlex` — SHACL PASS
- [x] `python3 scripts/shacl_validate_all.py --bucket sidecars` — SHACL PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)