### PR TITLE
#131 + #40: versioned-legal-text + practitioner-annotation models (schema-only)

### DIFF
--- a/docs/SCHEMA_REFERENCE.md
+++ b/docs/SCHEMA_REFERENCE.md
@@ -658,6 +658,154 @@ These properties enable cross-referencing between different parts of the legal s
 | `estleg:changeType` | DraftLegislation | `xsd:string` | Type of change: amends, repeals, supplements, enacts |
 | `estleg:affectedBy` | LegalProvision | DraftLegislation (IRI) | Pending drafts affecting this provision |
 
+### Provision versioning (historical redactions)
+
+**Status:** model defined (issue #131); **population is future work** — see issue #198.
+
+The enacted-law corpus is currently *current snapshot only*: each `estleg:LegalProvision`
+carries the text from one selected Riigi Teataja consolidated text (`terviktekst`), and
+`estleg:globalId` on the act node points at that one redaction. It does not yet carry the
+history of how a provision's text changed across earlier redactions.
+
+The `estleg:ProvisionVersion` model adds that capability. It keeps the **stable provision
+identity** (the `estleg:LegalProvision` IRI) deliberately separate from the
+**redaction/version identity** (the `estleg:ProvisionVersion` IRI), and records a
+non-overlapping validity interval per version.
+
+#### ProvisionVersion (`estleg:ProvisionVersion`)
+A redaction-specific version of a provision's text, with the interval over which that text
+was in force.
+
+| Property | Domain | Range | Cardinality | Description |
+|----------|--------|-------|-------------|-------------|
+| `estleg:versionOf` | ProvisionVersion | LegalProvision (IRI) | exactly 1 | The provision this version belongs to. Inverse of `estleg:hasVersion`. |
+| `estleg:versionValidFrom` | ProvisionVersion | `xsd:date` | exactly 1 | When this text became effective. |
+| `estleg:versionValidTo` | ProvisionVersion | `xsd:date` | 0–1 | When this text ceased to be in force. Absent ⇒ still current. |
+| `estleg:versionText` | ProvisionVersion | `xsd:string` | 1+ | The provision text at this redaction, verbatim. |
+| `estleg:versionRedactionId` | ProvisionVersion | `xsd:string` | 0–1 | The Riigi Teataja `terviktekstID` of the redaction that produced this text. |
+| `estleg:supersededByVersion` | ProvisionVersion | ProvisionVersion (IRI) | 0–1 | The chronologically next version of the same provision. Absent on the current version. |
+
+| Property | Domain | Range | Cardinality | Description |
+|----------|--------|-------|-------------|-------------|
+| `estleg:hasVersion` | LegalProvision | ProvisionVersion (IRI) | 0+ | A version in this provision's text history (one per redaction). Inverse of `estleg:versionOf`. Optional on `estleg:LegalProvisionShape`. |
+| `estleg:currentVersion` | LegalProvision | ProvisionVersion (IRI) | 0–1 | The latest version (the one with no `estleg:versionValidTo` / `estleg:supersededByVersion`). Convenience pointer; optional on `estleg:LegalProvisionShape`. |
+
+SHACL: `estleg:ProvisionVersionShape` (`sh:targetClass estleg:ProvisionVersion`) enforces the
+cardinalities above; `estleg:LegalProvisionShape` gains optional `estleg:hasVersion` /
+`estleg:currentVersion` property shapes (`sh:nodeKind sh:IRI`, `sh:minCount 0`) so existing
+provisions still conform.
+
+##### Example
+
+```json
+{
+  "@id": "estleg:LegalProvision_TsÜS_40_v1",
+  "@type": ["owl:NamedIndividual", "estleg:ProvisionVersion"],
+  "estleg:versionOf": {"@id": "estleg:LegalProvision_TsÜS_40"},
+  "estleg:versionValidFrom": {"@type": "xsd:date", "@value": "2011-07-01"},
+  "estleg:versionValidTo": {"@type": "xsd:date", "@value": "2018-12-31"},
+  "estleg:versionText": "§ 40. Tehing on toiming või omavahel seotud toimingute kogum, milles sisaldub kindla õigusliku tagajärje kaasatoomisele suunatud tahteavaldus.",
+  "estleg:versionRedactionId": "13335775",
+  "estleg:supersededByVersion": {"@id": "estleg:LegalProvision_TsÜS_40_v2"}
+}
+```
+```json
+{
+  "@id": "estleg:LegalProvision_TsÜS_40",
+  "@type": ["owl:NamedIndividual", "estleg:LegalProvision"],
+  "estleg:paragrahv": "TsÜS § 40",
+  "estleg:summary": "Defines what counts as a transaction (tehing).",
+  "estleg:hasVersion": [
+    {"@id": "estleg:LegalProvision_TsÜS_40_v1"},
+    {"@id": "estleg:LegalProvision_TsÜS_40_v2"}
+  ],
+  "estleg:currentVersion": {"@id": "estleg:LegalProvision_TsÜS_40_v2"}
+}
+```
+
+##### SPARQL — "what did § X say as of date D?"
+
+```sparql
+PREFIX estleg: <https://data.riik.ee/ontology/estleg#>
+PREFIX xsd:    <http://www.w3.org/2001/XMLSchema#>
+
+SELECT ?versionText WHERE {
+  ?provision estleg:paragrahv "TsÜS § 40" ;
+             estleg:hasVersion ?v .
+  ?v estleg:versionText     ?versionText ;
+     estleg:versionValidFrom ?from .
+  OPTIONAL { ?v estleg:versionValidTo ?to . }
+  FILTER ( ?from <= "2015-06-01"^^xsd:date
+           && ( !BOUND(?to) || ?to >= "2015-06-01"^^xsd:date ) )
+}
+```
+
+> **Population is future work.** No `estleg:ProvisionVersion` instances are emitted by any
+> generator today — the corpus remains current-snapshot-only. Building the version history
+> requires re-fetching every act at every historical redaction point and diffing provisions;
+> that ingestion is tracked in issue #198.
+
+### Annotations (practitioner layer)
+
+**Status:** model defined (issue #40); **population is future work** — see issue #199.
+
+The corpus captures the law *as written*, not how it is applied or interpreted in practice.
+The `estleg:Annotation` model adds a separate layer of practitioner-facing notes — guidance,
+commentary, practice notes, warnings, interpretations — attached to legal entities, without
+mixing them into the law-as-written nodes.
+
+#### Annotation (`estleg:Annotation`)
+A practitioner-facing note about a `Law`, an `estleg:LegalProvision`, a `MunicipalRegulation`,
+a `CourtDecision`, an EU instrument, etc.
+
+| Property | Domain | Range | Cardinality | Description |
+|----------|--------|-------|-------------|-------------|
+| `estleg:annotates` | Annotation | `owl:Thing` (IRI) | exactly 1 | The legal entity this annotation is about. Range is intentionally unconstrained — an annotation may attach to any legal entity. |
+| `estleg:annotationText` | Annotation | `xsd:string` | 1+ | The body of the note. |
+| `estleg:annotationType` | Annotation | `xsd:string` | exactly 1 | One of `guidance`, `commentary`, `practice_note`, `warning`, `interpretation` (SHACL `sh:in` enum). |
+| `estleg:annotationSource` | Annotation | `xsd:string` | 0–1 | Where the note comes from, as a string (e.g. `"Õiguskantsler"`, `"RT kommentaar"`, a publication name). String for now; a future iteration may make it an IRI to a source node. |
+| `estleg:annotationSourceUrl` | Annotation | `xsd:anyURI` | 0–1 | Optional link to the source document. |
+| `estleg:annotationDate` | Annotation | `xsd:date` | 0–1 | When the annotation was authored / published. |
+
+SHACL: `estleg:AnnotationShape` (`sh:targetClass estleg:Annotation`) requires
+`estleg:annotates` (exactly 1, IRI), `estleg:annotationText` (1+, string), and
+`estleg:annotationType` (exactly 1, string, `sh:in` the enum above); `estleg:annotationSource`,
+`estleg:annotationSourceUrl`, and `estleg:annotationDate` are optional with the datatypes above.
+
+##### Example
+
+```json
+{
+  "@id": "estleg:Annotation_OK_2020_TsÜS_40",
+  "@type": ["owl:NamedIndividual", "estleg:Annotation"],
+  "estleg:annotates": {"@id": "estleg:LegalProvision_TsÜS_40"},
+  "estleg:annotationText": "Õiguskantsler on rõhutanud, et tahteavalduse tuvastamisel tuleb arvestada poolte tegelikku tahet, mitte üksnes sõnastust.",
+  "estleg:annotationType": "interpretation",
+  "estleg:annotationSource": "Õiguskantsler",
+  "estleg:annotationSourceUrl": {"@type": "xsd:anyURI", "@value": "https://www.oiguskantsler.ee/et/seisukohad"},
+  "estleg:annotationDate": {"@type": "xsd:date", "@value": "2020-03-15"}
+}
+```
+
+##### SPARQL — annotations about a provision
+
+```sparql
+PREFIX estleg: <https://data.riik.ee/ontology/estleg#>
+
+SELECT ?text ?type ?source WHERE {
+  ?provision estleg:paragrahv "TsÜS § 40" .
+  ?ann estleg:annotates       ?provision ;
+       estleg:annotationText  ?text ;
+       estleg:annotationType  ?type .
+  OPTIONAL { ?ann estleg:annotationSource ?source . }
+}
+```
+
+> **Population is future work.** No `estleg:Annotation` instances exist today. Ingestion needs
+> a source-data decision first (Õiguskantsleri opinions? Riigi Teataja commentaries? ministry
+> guidelines?), then a parser that emits `estleg:Annotation` nodes linked to the annotated
+> entities; that work is tracked in issue #199.
+
 ### Normative Classification
 | Property | Domain | Range | Description |
 |----------|--------|-------|-------------|

--- a/krr_outputs/controlled_vocabulary.jsonld
+++ b/krr_outputs/controlled_vocabulary.jsonld
@@ -1971,6 +1971,182 @@
       "rdfs:range": {
         "@id": "xsd:string"
       }
+    },
+    {
+      "@id": "estleg:ProvisionVersion",
+      "@type": [
+        "owl:Class"
+      ],
+      "rdfs:label": "Provision Version",
+      "rdfs:comment": "A redaction-specific version of an estleg:LegalProvision's text. Each ProvisionVersion captures the text a provision carried during one Riigi Teataja consolidated-text redaction (terviktekst), together with the validity interval over which that text was in force. Defined for issue #131; population from historical Riigi Teataja redactions is tracked separately (see the follow-up data-completeness issue)."
+    },
+    {
+      "@id": "estleg:versionOf",
+      "@type": [
+        "owl:ObjectProperty"
+      ],
+      "rdfs:label": "Version Of",
+      "rdfs:comment": "Links an estleg:ProvisionVersion to the estleg:LegalProvision whose text it captures. The stable provision identity (the LegalProvision IRI) is deliberately distinct from the redaction/version identity (the ProvisionVersion IRI). Inverse of estleg:hasVersion.",
+      "rdfs:range": {
+        "@id": "estleg:LegalProvision"
+      },
+      "owl:inverseOf": {
+        "@id": "estleg:hasVersion"
+      }
+    },
+    {
+      "@id": "estleg:versionValidFrom",
+      "@type": [
+        "owl:DatatypeProperty"
+      ],
+      "rdfs:label": "Version Valid From",
+      "rdfs:comment": "Date on which this provision text became effective (the entry-into-force date of the redaction that introduced it).",
+      "rdfs:range": {
+        "@id": "xsd:date"
+      }
+    },
+    {
+      "@id": "estleg:versionValidTo",
+      "@type": [
+        "owl:DatatypeProperty"
+      ],
+      "rdfs:label": "Version Valid To",
+      "rdfs:comment": "Date on which this provision text ceased to be in force (the day before the next redaction took effect). Absent when this is the current text.",
+      "rdfs:range": {
+        "@id": "xsd:date"
+      }
+    },
+    {
+      "@id": "estleg:versionText",
+      "@type": [
+        "owl:DatatypeProperty"
+      ],
+      "rdfs:label": "Version Text",
+      "rdfs:comment": "The provision text at this redaction, verbatim.",
+      "rdfs:range": {
+        "@id": "xsd:string"
+      }
+    },
+    {
+      "@id": "estleg:versionRedactionId",
+      "@type": [
+        "owl:DatatypeProperty"
+      ],
+      "rdfs:label": "Version Redaction Id",
+      "rdfs:comment": "The Riigi Teataja terviktekstID (consolidated-text identifier) of the redaction that produced this provision text. Ties the version to its concrete source document, mirroring how estleg:globalId ties an act snapshot to one concrete redaction.",
+      "rdfs:range": {
+        "@id": "xsd:string"
+      }
+    },
+    {
+      "@id": "estleg:supersededByVersion",
+      "@type": [
+        "owl:ObjectProperty"
+      ],
+      "rdfs:label": "Superseded By Version",
+      "rdfs:comment": "Links an estleg:ProvisionVersion to the chronologically next estleg:ProvisionVersion of the same provision. Absent on the current (latest) version. Forms a single-successor chain so consumers can walk a provision's text history forward.",
+      "rdfs:range": {
+        "@id": "estleg:ProvisionVersion"
+      }
+    },
+    {
+      "@id": "estleg:hasVersion",
+      "@type": [
+        "owl:ObjectProperty"
+      ],
+      "rdfs:label": "Has Version",
+      "rdfs:comment": "Links an estleg:LegalProvision to an estleg:ProvisionVersion in its text history. A provision with a populated history has one estleg:hasVersion triple per redaction. Inverse of estleg:versionOf.",
+      "rdfs:range": {
+        "@id": "estleg:ProvisionVersion"
+      },
+      "owl:inverseOf": {
+        "@id": "estleg:versionOf"
+      }
+    },
+    {
+      "@id": "estleg:currentVersion",
+      "@type": [
+        "owl:ObjectProperty"
+      ],
+      "rdfs:label": "Current Version",
+      "rdfs:comment": "Links an estleg:LegalProvision to the latest estleg:ProvisionVersion in its text history (the one with no estleg:versionValidTo and no estleg:supersededByVersion). Convenience pointer so consumers do not have to scan the whole estleg:hasVersion set.",
+      "rdfs:range": {
+        "@id": "estleg:ProvisionVersion"
+      }
+    },
+    {
+      "@id": "estleg:Annotation",
+      "@type": [
+        "owl:Class"
+      ],
+      "rdfs:label": "Annotation",
+      "rdfs:comment": "A practitioner-facing note (guidance, commentary, practice note, warning, or interpretation) about a legal entity — a Law, an estleg:LegalProvision, a MunicipalRegulation, a CourtDecision, and so on. The annotation layer records how the law is applied or interpreted in practice, alongside (not inside) the law-as-written corpus. Defined for issue #40; ingestion of annotation source data is tracked separately (see the follow-up data-completeness issue)."
+    },
+    {
+      "@id": "estleg:annotates",
+      "@type": [
+        "owl:ObjectProperty"
+      ],
+      "rdfs:label": "Annotates",
+      "rdfs:comment": "Links an estleg:Annotation to the legal entity it is about. The range is intentionally unconstrained (owl:Thing): an annotation may attach to a Law, an estleg:LegalProvision, a MunicipalRegulation, a CourtDecision, an EU instrument, etc.",
+      "rdfs:range": {
+        "@id": "owl:Thing"
+      }
+    },
+    {
+      "@id": "estleg:annotationText",
+      "@type": [
+        "owl:DatatypeProperty"
+      ],
+      "rdfs:label": "Annotation Text",
+      "rdfs:comment": "The body of the annotation — the practitioner note itself.",
+      "rdfs:range": {
+        "@id": "xsd:string"
+      }
+    },
+    {
+      "@id": "estleg:annotationSource",
+      "@type": [
+        "owl:DatatypeProperty"
+      ],
+      "rdfs:label": "Annotation Source",
+      "rdfs:comment": "Where the annotation comes from, as a human-readable string (e.g. \"Õiguskantsler\", \"RT kommentaar\", a commentary publication name). Kept as a string for now; a future iteration may replace it with an IRI to a source node.",
+      "rdfs:range": {
+        "@id": "xsd:string"
+      }
+    },
+    {
+      "@id": "estleg:annotationSourceUrl",
+      "@type": [
+        "owl:DatatypeProperty"
+      ],
+      "rdfs:label": "Annotation Source Url",
+      "rdfs:comment": "Optional link to the annotation's source document.",
+      "rdfs:range": {
+        "@id": "xsd:anyURI"
+      }
+    },
+    {
+      "@id": "estleg:annotationDate",
+      "@type": [
+        "owl:DatatypeProperty"
+      ],
+      "rdfs:label": "Annotation Date",
+      "rdfs:comment": "Date on which the annotation was authored or published.",
+      "rdfs:range": {
+        "@id": "xsd:date"
+      }
+    },
+    {
+      "@id": "estleg:annotationType",
+      "@type": [
+        "owl:DatatypeProperty"
+      ],
+      "rdfs:label": "Annotation Type",
+      "rdfs:comment": "Category of the annotation. SHACL constrains it to one of: \"guidance\", \"commentary\", \"practice_note\", \"warning\", \"interpretation\".",
+      "rdfs:range": {
+        "@id": "xsd:string"
+      }
     }
   ]
 }

--- a/shacl/estonian_legal_shapes.ttl
+++ b/shacl/estonian_legal_shapes.ttl
@@ -222,6 +222,25 @@ estleg:LegalProvisionShape
         sh:nodeKind sh:IRI ;
         sh:name "harmonisedWith" ;
         sh:description "EU or international legislation this provision is harmonised with" ;
+    ] ;
+    # --- versioned legal-text model (issue #131) ---
+    # Both optional: the corpus is currently "current snapshot only" and
+    # carries no estleg:ProvisionVersion nodes yet. When a provision's
+    # text history is populated, estleg:hasVersion lists every redaction
+    # version and estleg:currentVersion points at the latest one.
+    sh:property [
+        sh:path estleg:hasVersion ;
+        sh:minCount 0 ;
+        sh:nodeKind sh:IRI ;
+        sh:name "hasVersion" ;
+        sh:description "Optional — estleg:ProvisionVersion nodes in this provision's text history (one per Riigi Teataja redaction). Population is future work (#131 follow-up)." ;
+    ] ;
+    sh:property [
+        sh:path estleg:currentVersion ;
+        sh:minCount 0 ;
+        sh:nodeKind sh:IRI ;
+        sh:name "currentVersion" ;
+        sh:description "Optional — the latest estleg:ProvisionVersion in this provision's text history. Population is future work (#131 follow-up)." ;
     ] .
 
 # Shape for TopicCluster instances.
@@ -1174,4 +1193,131 @@ estleg:CitationShape
         sh:maxCount 1 ;
         sh:datatype xsd:string ;
         sh:name "citationText" ;
+    ] .
+
+# ============================================================
+# Versioned legal-text model — issue #131 (model only; population deferred)
+# ============================================================
+#
+# An estleg:ProvisionVersion captures the text an estleg:LegalProvision
+# carried during one Riigi Teataja consolidated-text redaction, plus the
+# validity interval over which that text was in force. The redaction/version
+# identity (the ProvisionVersion IRI) is deliberately separate from the
+# stable provision identity (the LegalProvision IRI, reached via
+# estleg:versionOf). No corpus instances exist yet — see the #131
+# follow-up data-completeness issue for the ingestion plan; this shape
+# is the model the ingestion must satisfy.
+estleg:ProvisionVersionShape
+    a sh:NodeShape ;
+    sh:targetClass estleg:ProvisionVersion ;
+    sh:property [
+        sh:path estleg:versionOf ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:IRI ;
+        sh:name "versionOf" ;
+        sh:description "Exactly one estleg:LegalProvision this version belongs to (an IRI)." ;
+    ] ;
+    sh:property [
+        sh:path estleg:versionValidFrom ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:date ;
+        sh:name "versionValidFrom" ;
+        sh:description "Date this provision text became effective." ;
+    ] ;
+    sh:property [
+        sh:path estleg:versionValidTo ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:date ;
+        sh:name "versionValidTo" ;
+        sh:description "Date this provision text ceased to be in force. Absent ⇒ still current." ;
+    ] ;
+    sh:property [
+        sh:path estleg:versionText ;
+        sh:minCount 1 ;
+        sh:datatype xsd:string ;
+        sh:name "versionText" ;
+        sh:description "The provision text at this redaction, verbatim." ;
+    ] ;
+    sh:property [
+        sh:path estleg:versionRedactionId ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:string ;
+        sh:name "versionRedactionId" ;
+        sh:description "Riigi Teataja terviktekstID of the redaction that produced this text." ;
+    ] ;
+    sh:property [
+        sh:path estleg:supersededByVersion ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:IRI ;
+        sh:name "supersededByVersion" ;
+        sh:description "The chronologically next estleg:ProvisionVersion of the same provision (an IRI). Absent on the current version." ;
+    ] .
+
+# ============================================================
+# Practitioner annotation layer — issue #40 (model only; ingestion deferred)
+# ============================================================
+#
+# An estleg:Annotation is a practitioner-facing note (guidance, commentary,
+# practice note, warning, interpretation) attached to a legal entity — a
+# Law, an estleg:LegalProvision, a MunicipalRegulation, a CourtDecision,
+# an EU instrument, etc. estleg:annotates is intentionally only constrained
+# to be an IRI here (not sh:class), mirroring the project-wide convention
+# of avoiding sh:class on cross-typed targets. No corpus instances exist
+# yet — see the #40 follow-up data-completeness issue for the source
+# decision and ingestion plan.
+estleg:AnnotationShape
+    a sh:NodeShape ;
+    sh:targetClass estleg:Annotation ;
+    sh:property [
+        sh:path estleg:annotates ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:IRI ;
+        sh:name "annotates" ;
+        sh:description "Exactly one legal entity this annotation is about (an IRI)." ;
+    ] ;
+    sh:property [
+        sh:path estleg:annotationText ;
+        sh:minCount 1 ;
+        sh:datatype xsd:string ;
+        sh:name "annotationText" ;
+        sh:description "The body of the annotation." ;
+    ] ;
+    sh:property [
+        sh:path estleg:annotationType ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:string ;
+        sh:in ( "guidance" "commentary" "practice_note" "warning" "interpretation" ) ;
+        sh:name "annotationType" ;
+        sh:description "Category of the annotation: guidance, commentary, practice_note, warning, or interpretation." ;
+    ] ;
+    sh:property [
+        sh:path estleg:annotationSource ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:string ;
+        sh:name "annotationSource" ;
+        sh:description "Where the note comes from, as a human-readable string (e.g. \"Õiguskantsler\", \"RT kommentaar\")." ;
+    ] ;
+    sh:property [
+        sh:path estleg:annotationSourceUrl ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:anyURI ;
+        sh:name "annotationSourceUrl" ;
+        sh:description "Optional link to the annotation's source document." ;
+    ] ;
+    sh:property [
+        sh:path estleg:annotationDate ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:date ;
+        sh:name "annotationDate" ;
+        sh:description "Date the annotation was authored or published." ;
     ] .

--- a/tests/test_schema_model.py
+++ b/tests/test_schema_model.py
@@ -1,0 +1,309 @@
+"""Schema-model tests for the versioned legal-text model (#131) and the
+practitioner annotation layer (#40).
+
+Two things are checked:
+
+1. The new reusable vocabulary terms are declared in
+   ``krr_outputs/controlled_vocabulary.jsonld`` with the right OWL types
+   (so the vocabulary-coverage gate will accept them once data uses them).
+2. The new SHACL shapes (``estleg:ProvisionVersionShape``,
+   ``estleg:AnnotationShape``) accept hand-built well-formed instances and
+   reject instances that are missing required properties or violate the
+   ``annotationType`` enum — and a ``estleg:LegalProvision`` carrying the
+   optional ``estleg:hasVersion`` / ``estleg:currentVersion`` properties
+   still conforms to ``estleg:LegalProvisionShape``.
+
+Population of either model is future work — see the follow-up
+data-completeness issues referenced from ``docs/SCHEMA_REFERENCE.md``.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import pytest
+
+import validate_all
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SHAPES = REPO_ROOT / "shacl" / "estonian_legal_shapes.ttl"
+VOCAB = REPO_ROOT / "krr_outputs" / "controlled_vocabulary.jsonld"
+
+CONTEXT = {
+    "estleg": "https://data.riik.ee/ontology/estleg#",
+    "owl": "http://www.w3.org/2002/07/owl#",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+}
+
+
+def _validate(graph_json: dict) -> tuple[bool, str]:
+    pyshacl = pytest.importorskip("pyshacl")
+    rdflib = pytest.importorskip("rdflib")
+    g = rdflib.Graph()
+    g.parse(data=json.dumps(graph_json), format="json-ld")
+    shapes = rdflib.Graph().parse(str(SHAPES), format="turtle")
+    conforms, _, msg = pyshacl.validate(g, shacl_graph=shapes, inference="rdfs")
+    return conforms, str(msg)
+
+
+def _vocab_index() -> dict[str, dict]:
+    doc = json.loads(VOCAB.read_text(encoding="utf-8"))
+    return {n["@id"]: n for n in doc["@graph"] if isinstance(n, dict) and n.get("@id")}
+
+
+def _has_type(node: dict, owl_type: str) -> bool:
+    t = node.get("@type")
+    if isinstance(t, list):
+        return owl_type in t
+    return t == owl_type
+
+
+# ---------------------------------------------------------------------------
+# Vocabulary terms — issue #131
+# ---------------------------------------------------------------------------
+
+PROVISION_VERSION_CLASSES = ["estleg:ProvisionVersion"]
+PROVISION_VERSION_OBJECT_PROPS = [
+    "estleg:versionOf",
+    "estleg:supersededByVersion",
+    "estleg:hasVersion",
+    "estleg:currentVersion",
+]
+PROVISION_VERSION_DATATYPE_PROPS = [
+    "estleg:versionValidFrom",
+    "estleg:versionValidTo",
+    "estleg:versionText",
+    "estleg:versionRedactionId",
+]
+
+# ---------------------------------------------------------------------------
+# Vocabulary terms — issue #40
+# ---------------------------------------------------------------------------
+
+ANNOTATION_CLASSES = ["estleg:Annotation"]
+ANNOTATION_OBJECT_PROPS = ["estleg:annotates"]
+ANNOTATION_DATATYPE_PROPS = [
+    "estleg:annotationText",
+    "estleg:annotationSource",
+    "estleg:annotationSourceUrl",
+    "estleg:annotationDate",
+    "estleg:annotationType",
+]
+
+
+@pytest.mark.parametrize("term", PROVISION_VERSION_CLASSES + ANNOTATION_CLASSES)
+def test_new_classes_declared_as_owl_class(term):
+    node = _vocab_index().get(term)
+    assert node is not None, f"{term} missing from controlled_vocabulary.jsonld"
+    assert _has_type(node, "owl:Class"), f"{term} is not an owl:Class"
+    assert node.get("rdfs:label"), f"{term} lacks rdfs:label"
+    assert node.get("rdfs:comment"), f"{term} lacks rdfs:comment"
+
+
+@pytest.mark.parametrize("term", PROVISION_VERSION_OBJECT_PROPS + ANNOTATION_OBJECT_PROPS)
+def test_new_object_properties_declared(term):
+    node = _vocab_index().get(term)
+    assert node is not None, f"{term} missing from controlled_vocabulary.jsonld"
+    assert _has_type(node, "owl:ObjectProperty"), f"{term} is not an owl:ObjectProperty"
+    assert node.get("rdfs:label"), f"{term} lacks rdfs:label"
+    assert node.get("rdfs:comment"), f"{term} lacks rdfs:comment"
+
+
+@pytest.mark.parametrize("term", PROVISION_VERSION_DATATYPE_PROPS + ANNOTATION_DATATYPE_PROPS)
+def test_new_datatype_properties_declared(term):
+    node = _vocab_index().get(term)
+    assert node is not None, f"{term} missing from controlled_vocabulary.jsonld"
+    assert _has_type(node, "owl:DatatypeProperty"), f"{term} is not an owl:DatatypeProperty"
+    assert node.get("rdfs:label"), f"{term} lacks rdfs:label"
+    assert node.get("rdfs:comment"), f"{term} lacks rdfs:comment"
+
+
+def test_hasversion_versionof_inverse_pair_declared():
+    idx = _vocab_index()
+    assert idx["estleg:hasVersion"].get("owl:inverseOf") == {"@id": "estleg:versionOf"}
+    assert idx["estleg:versionOf"].get("owl:inverseOf") == {"@id": "estleg:hasVersion"}
+
+
+def test_new_terms_are_collected_as_defined_vocabulary():
+    """The vocabulary-coverage gate must recognise the new terms — they are
+    declared in controlled_vocabulary.jsonld even though no data uses them
+    yet (defined-but-unused is fine; used-but-undefined is the failure)."""
+    defined = validate_all.collect_defined_vocabulary_terms()
+    for term in (
+        PROVISION_VERSION_CLASSES
+        + PROVISION_VERSION_OBJECT_PROPS
+        + PROVISION_VERSION_DATATYPE_PROPS
+        + ANNOTATION_CLASSES
+        + ANNOTATION_OBJECT_PROPS
+        + ANNOTATION_DATATYPE_PROPS
+    ):
+        assert term in defined, f"{term} not seen by collect_defined_vocabulary_terms()"
+
+
+# ---------------------------------------------------------------------------
+# SHACL — estleg:ProvisionVersionShape (#131)
+# ---------------------------------------------------------------------------
+
+_PV_VALID = {
+    "@context": CONTEXT,
+    "@id": "estleg:LegalProvision_TEST_1_v1",
+    "@type": "estleg:ProvisionVersion",
+    "estleg:versionOf": {"@id": "estleg:LegalProvision_TEST_1"},
+    "estleg:versionValidFrom": {"@type": "xsd:date", "@value": "2015-01-01"},
+    "estleg:versionValidTo": {"@type": "xsd:date", "@value": "2019-12-31"},
+    "estleg:versionText": "§ 1. Vana sõnastus.",
+    "estleg:versionRedactionId": "123456789",
+    "estleg:supersededByVersion": {"@id": "estleg:LegalProvision_TEST_1_v2"},
+}
+
+
+class TestProvisionVersionShape:
+    def test_well_formed_conforms(self):
+        ok, msg = _validate(dict(_PV_VALID))
+        assert ok, msg
+
+    def test_minimal_well_formed_conforms(self):
+        # Only the required properties — validTo / redactionId / supersededBy omitted.
+        ok, msg = _validate({
+            "@context": CONTEXT,
+            "@id": "estleg:LegalProvision_TEST_1_v2",
+            "@type": "estleg:ProvisionVersion",
+            "estleg:versionOf": {"@id": "estleg:LegalProvision_TEST_1"},
+            "estleg:versionValidFrom": {"@type": "xsd:date", "@value": "2020-01-01"},
+            "estleg:versionText": "§ 1. Uus sõnastus.",
+        })
+        assert ok, msg
+
+    def test_missing_version_of_rejected(self):
+        node = dict(_PV_VALID)
+        del node["estleg:versionOf"]
+        ok, _ = _validate(node)
+        assert not ok
+
+    def test_missing_version_valid_from_rejected(self):
+        node = dict(_PV_VALID)
+        del node["estleg:versionValidFrom"]
+        ok, _ = _validate(node)
+        assert not ok
+
+    def test_missing_version_text_rejected(self):
+        node = dict(_PV_VALID)
+        del node["estleg:versionText"]
+        ok, _ = _validate(node)
+        assert not ok
+
+    def test_version_of_literal_not_iri_rejected(self):
+        node = dict(_PV_VALID)
+        node["estleg:versionOf"] = "estleg:LegalProvision_TEST_1"
+        ok, _ = _validate(node)
+        assert not ok
+
+
+# ---------------------------------------------------------------------------
+# SHACL — estleg:AnnotationShape (#40)
+# ---------------------------------------------------------------------------
+
+_ANN_VALID = {
+    "@context": CONTEXT,
+    "@id": "estleg:Annotation_TEST_1",
+    "@type": "estleg:Annotation",
+    "estleg:annotates": {"@id": "estleg:KOKS_Par_22"},
+    "estleg:annotationText": "Õiguskantsler on selgitanud, et seda sätet tuleb tõlgendada kitsalt.",
+    "estleg:annotationType": "interpretation",
+    "estleg:annotationSource": "Õiguskantsler",
+    "estleg:annotationSourceUrl": {"@type": "xsd:anyURI", "@value": "https://www.oiguskantsler.ee/et/arvamus"},
+    "estleg:annotationDate": {"@type": "xsd:date", "@value": "2020-03-15"},
+}
+
+
+class TestAnnotationShape:
+    def test_well_formed_conforms(self):
+        ok, msg = _validate(dict(_ANN_VALID))
+        assert ok, msg
+
+    def test_minimal_well_formed_conforms(self):
+        ok, msg = _validate({
+            "@context": CONTEXT,
+            "@id": "estleg:Annotation_TEST_2",
+            "@type": "estleg:Annotation",
+            "estleg:annotates": {"@id": "estleg:KOKS_Par_22"},
+            "estleg:annotationText": "Praktikas kohaldatakse seda paindlikult.",
+            "estleg:annotationType": "practice_note",
+        })
+        assert ok, msg
+
+    @pytest.mark.parametrize(
+        "kind", ["guidance", "commentary", "practice_note", "warning", "interpretation"]
+    )
+    def test_all_enum_values_accepted(self, kind):
+        node = dict(_ANN_VALID)
+        node["estleg:annotationType"] = kind
+        ok, msg = _validate(node)
+        assert ok, msg
+
+    def test_missing_annotates_rejected(self):
+        node = dict(_ANN_VALID)
+        del node["estleg:annotates"]
+        ok, _ = _validate(node)
+        assert not ok
+
+    def test_missing_annotation_text_rejected(self):
+        node = dict(_ANN_VALID)
+        del node["estleg:annotationText"]
+        ok, _ = _validate(node)
+        assert not ok
+
+    def test_missing_annotation_type_rejected(self):
+        node = dict(_ANN_VALID)
+        del node["estleg:annotationType"]
+        ok, _ = _validate(node)
+        assert not ok
+
+    def test_out_of_enum_annotation_type_rejected(self):
+        node = dict(_ANN_VALID)
+        node["estleg:annotationType"] = "bogus_category"
+        ok, _ = _validate(node)
+        assert not ok
+
+    def test_annotates_literal_not_iri_rejected(self):
+        node = dict(_ANN_VALID)
+        node["estleg:annotates"] = "estleg:KOKS_Par_22"
+        ok, _ = _validate(node)
+        assert not ok
+
+
+# ---------------------------------------------------------------------------
+# SHACL — estleg:LegalProvisionShape still accepts hasVersion / currentVersion
+# ---------------------------------------------------------------------------
+
+
+def test_legal_provision_with_version_links_conforms():
+    ok, msg = _validate({
+        "@context": CONTEXT,
+        "@id": "estleg:LegalProvision_TEST_1",
+        "@type": ["owl:NamedIndividual", "estleg:LegalProvision"],
+        "estleg:paragrahv": "§ 1",
+        "estleg:summary": "Test provision used in the schema-model test.",
+        "estleg:hasVersion": [
+            {"@id": "estleg:LegalProvision_TEST_1_v1"},
+            {"@id": "estleg:LegalProvision_TEST_1_v2"},
+        ],
+        "estleg:currentVersion": {"@id": "estleg:LegalProvision_TEST_1_v2"},
+    })
+    assert ok, msg
+
+
+def test_legal_provision_without_version_links_still_conforms():
+    ok, msg = _validate({
+        "@context": CONTEXT,
+        "@id": "estleg:LegalProvision_TEST_2",
+        "@type": ["owl:NamedIndividual", "estleg:LegalProvision"],
+        "estleg:paragrahv": "§ 2",
+        "estleg:summary": "Provision with no version history populated.",
+    })
+    assert ok, msg


### PR DESCRIPTION
## Summary
Defines the ontology model for both tickets; data population is split into follow-ups (#198, #199). Pure vocab + SHACL + docs + tests — no corpus instances.

- **#131** — `estleg:ProvisionVersion` (+ `versionOf`/`versionValidFrom`/`versionValidTo`/`versionText`/`versionRedactionId`/`supersededByVersion`/`hasVersion`/`currentVersion`) for historical redaction versions of a provision's text; `ProvisionVersionShape` + optional `hasVersion`/`currentVersion` on `LegalProvisionShape`. Follow-up #198 for population.
- **#40** — `estleg:Annotation` (+ `annotates`/`annotationText`/`annotationSource`/`annotationSourceUrl`/`annotationDate`/`annotationType`) for practitioner/guidance notes; `AnnotationShape` (with `sh:in` enum on `annotationType`). Follow-up #199 for ingestion (needs a source decision).
- `docs/SCHEMA_REFERENCE.md` gains both subsections; `combined_ontology.jsonld` regenerated for the new vocab defs; +38 tests (`tests/test_schema_model.py`).

## Test plan
- [x] `pytest tests/` — 1,265 passed, 2 skipped
- [x] `ruff check scripts/ tests/` — clean
- [x] `python3 scripts/validate_all.py` — 0 errors / 1 benign warning
- [x] `python3 scripts/validate_seadusloome_sync.py` — SHACL PASS
- [x] `python3 scripts/shacl_validate_all.py --bucket laws` — SHACL PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)