### PR TITLE
#130: model historical KOV jurisdictions as estleg:HistoricalMunicipality

### DIFF
--- a/data/ehak/historical_municipalities.jsonld
+++ b/data/ehak/historical_municipalities.jsonld
@@ -1,0 +1,2875 @@
+{
+  "@context": {
+    "estleg": "https://data.riik.ee/ontology/estleg#",
+    "owl": "http://www.w3.org/2002/07/owl#",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "dc": "http://purl.org/dc/elements/1.1/",
+    "dcterms": "http://purl.org/dc/terms/",
+    "skos": "http://www.w3.org/2004/02/skos/core#"
+  },
+  "@graph": [
+    {
+      "@id": "estleg:HistoricalMunicipalities_Map_2026",
+      "@type": [
+        "owl:Ontology"
+      ],
+      "rdfs:label": "Estonian Historical Municipalities (pre-merger KOV units)",
+      "rdfs:comment": "Former Estonian municipalities abolished by territorial reform (chiefly the 2017 haldusreform). Each node links to its surviving successor via estleg:succeededBy. Derived from the issuer registry's mappingEvidence citations; see issue #130.",
+      "dcterms:source": {
+        "@id": "https://data.riik.ee/ontology/estleg#Issuers_Kov_Map_2026"
+      }
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0105",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Abja vald",
+      "estleg:formerEhakCode": "0105",
+      "estleg:formerName": "Abja vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0480"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Abja vald (EHAK 0105) -> Mulgi vald (EHAK 0480); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0112",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Aegviidu vald",
+      "estleg:formerEhakCode": "0112",
+      "estleg:formerName": "Aegviidu vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0141"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Aegviidu vald (EHAK 0112) -> Anija vald (EHAK 0141); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0117",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Ahja vald",
+      "estleg:formerEhakCode": "0117",
+      "estleg:formerName": "Ahja vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0622"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Ahja vald (EHAK 0117) -> Põlva vald (EHAK 0622); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0122",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Alajõe vald",
+      "estleg:formerEhakCode": "0122",
+      "estleg:formerName": "Alajõe vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0130"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Alajõe vald (EHAK 0122) -> Alutaguse vald (EHAK 0130); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0126",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Alatskivi vald",
+      "estleg:formerEhakCode": "0126",
+      "estleg:formerName": "Alatskivi vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0586"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Alatskivi vald (EHAK 0126) -> Peipsiääre vald (EHAK 0586); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0134",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Ambla vald",
+      "estleg:formerEhakCode": "0134",
+      "estleg:formerName": "Ambla vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0255"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Ambla vald (EHAK 0134) -> Järva vald (EHAK 0255); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0149",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Are vald",
+      "estleg:formerEhakCode": "0149",
+      "estleg:formerName": "Are vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0809"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Are vald (EHAK 0149) -> Tori vald (EHAK 0809); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0154",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Aseri vald",
+      "estleg:formerEhakCode": "0154",
+      "estleg:formerName": "Aseri vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0903"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Aseri vald (EHAK 0154) -> Viru-Nigula vald (EHAK 0903); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0160",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Audru vald",
+      "estleg:formerEhakCode": "0160",
+      "estleg:formerName": "Audru vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0624"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Audru vald (EHAK 0160) -> Pärnu linn (EHAK 0624); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0164",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Avinurme vald",
+      "estleg:formerEhakCode": "0164",
+      "estleg:formerName": "Avinurme vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0486"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Avinurme vald (EHAK 0164) -> Mustvee vald (EHAK 0486); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0170",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Elva linn",
+      "estleg:formerEhakCode": "0170",
+      "estleg:formerName": "Elva linn",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0171"
+      },
+      "estleg:municipalityType": "linn",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Elva linn (EHAK 0170) -> Elva vald (EHAK 0171); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0175",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Emmaste vald",
+      "estleg:formerEhakCode": "0175",
+      "estleg:formerName": "Emmaste vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0205"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Emmaste vald (EHAK 0175) -> Hiiumaa vald (EHAK 0205); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0181",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Haanja vald",
+      "estleg:formerEhakCode": "0181",
+      "estleg:formerName": "Haanja vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0698"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Haanja vald (EHAK 0181) -> Rõuge vald (EHAK 0698); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0185",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Haaslava vald",
+      "estleg:formerEhakCode": "0185",
+      "estleg:formerName": "Haaslava vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0291"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Haaslava vald (EHAK 0185) -> Kastre vald (EHAK 0291); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0188",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Halinga vald",
+      "estleg:formerEhakCode": "0188",
+      "estleg:formerName": "Halinga vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0638"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Halinga vald (EHAK 0188) -> Põhja-Pärnumaa vald (EHAK 0638); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0192",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Halliste vald",
+      "estleg:formerEhakCode": "0192",
+      "estleg:formerName": "Halliste vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0480"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Halliste vald (EHAK 0192) -> Mulgi vald (EHAK 0480); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0195",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Hanila vald",
+      "estleg:formerEhakCode": "0195",
+      "estleg:formerName": "Hanila vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0430"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Hanila vald (EHAK 0195) -> Lääneranna vald (EHAK 0430); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0203",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Helme vald",
+      "estleg:formerEhakCode": "0203",
+      "estleg:formerName": "Helme vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0824"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Helme vald (EHAK 0203) -> Tõrva vald (EHAK 0824); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0204",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Hiiu vald",
+      "estleg:formerEhakCode": "0204",
+      "estleg:formerName": "Hiiu vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0205"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Hiiu vald (EHAK 0204) -> Hiiumaa vald (EHAK 0205); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0208",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Hummuli vald",
+      "estleg:formerEhakCode": "0208",
+      "estleg:formerName": "Hummuli vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0824"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Hummuli vald (EHAK 0208) -> Tõrva vald (EHAK 0824); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0224",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Iisaku vald",
+      "estleg:formerEhakCode": "0224",
+      "estleg:formerName": "Iisaku vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0130"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Iisaku vald (EHAK 0224) -> Alutaguse vald (EHAK 0130); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0229",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Illuka vald",
+      "estleg:formerEhakCode": "0229",
+      "estleg:formerName": "Illuka vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0130"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Illuka vald (EHAK 0229) -> Alutaguse vald (EHAK 0130); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0234",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Imavere vald",
+      "estleg:formerEhakCode": "0234",
+      "estleg:formerName": "Imavere vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0255"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Imavere vald (EHAK 0234) -> Järva vald (EHAK 0255); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0240",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Juuru vald",
+      "estleg:formerEhakCode": "0240",
+      "estleg:formerName": "Juuru vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0668"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Juuru vald (EHAK 0240) -> Rapla vald (EHAK 0668); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0249",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Jõgeva linn",
+      "estleg:formerEhakCode": "0249",
+      "estleg:formerName": "Jõgeva linn",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0247"
+      },
+      "estleg:municipalityType": "linn",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Jõgeva linn (EHAK 0249) -> Jõgeva vald (EHAK 0247); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0257",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Järva-Jaani vald",
+      "estleg:formerEhakCode": "0257",
+      "estleg:formerName": "Järva-Jaani vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0255"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Järva-Jaani vald (EHAK 0257) -> Järva vald (EHAK 0255); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0260",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Järvakandi vald",
+      "estleg:formerEhakCode": "0260",
+      "estleg:formerName": "Järvakandi vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0293"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Järvakandi vald (EHAK 0260) -> Kehtna vald (EHAK 0293); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0270",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Kaarma vald",
+      "estleg:formerEhakCode": "0270",
+      "estleg:formerName": "Kaarma vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0714"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Kaarma vald (EHAK 0270) -> Saaremaa vald (EHAK 0714); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0277",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Kaiu vald",
+      "estleg:formerEhakCode": "0277",
+      "estleg:formerName": "Kaiu vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0668"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Kaiu vald (EHAK 0277) -> Rapla vald (EHAK 0668); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0279",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Kallaste linn",
+      "estleg:formerEhakCode": "0279",
+      "estleg:formerName": "Kallaste linn",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0586"
+      },
+      "estleg:municipalityType": "linn",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Kallaste linn (EHAK 0279) -> Peipsiääre vald (EHAK 0586); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0288",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Kareda vald",
+      "estleg:formerEhakCode": "0288",
+      "estleg:formerName": "Kareda vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0255"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Kareda vald (EHAK 0288) -> Järva vald (EHAK 0255); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0289",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Karula vald",
+      "estleg:formerEhakCode": "0289",
+      "estleg:formerName": "Karula vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0855"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Karula vald (EHAK 0289) -> Valga vald (EHAK 0855); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0295",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Keila vald",
+      "estleg:formerEhakCode": "0295",
+      "estleg:formerName": "Keila vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0431"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Keila vald (EHAK 0295) -> Lääne-Harju vald (EHAK 0431); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0297",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Kernu vald",
+      "estleg:formerEhakCode": "0297",
+      "estleg:formerName": "Kernu vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0726"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Kernu vald (EHAK 0297) -> Saue vald (EHAK 0726); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0301",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Kihelkonna vald",
+      "estleg:formerEhakCode": "0301",
+      "estleg:formerName": "Kihelkonna vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0714"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Kihelkonna vald (EHAK 0301) -> Saaremaa vald (EHAK 0714); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0309",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Kiviõli linn",
+      "estleg:formerEhakCode": "0309",
+      "estleg:formerName": "Kiviõli linn",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0442"
+      },
+      "estleg:municipalityType": "linn",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Kiviõli linn (EHAK 0309) -> Lüganuse vald (EHAK 0442); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0314",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Koeru vald",
+      "estleg:formerEhakCode": "0314",
+      "estleg:formerName": "Koeru vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0255"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Koeru vald (EHAK 0314) -> Järva vald (EHAK 0255); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0320",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Kohtla vald",
+      "estleg:formerEhakCode": "0320",
+      "estleg:formerName": "Kohtla vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0803"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Kohtla vald (EHAK 0320) -> Toila vald (EHAK 0803); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0323",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Kohtla-Nõmme vald",
+      "estleg:formerEhakCode": "0323",
+      "estleg:formerName": "Kohtla-Nõmme vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0803"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Kohtla-Nõmme vald (EHAK 0323) -> Toila vald (EHAK 0803); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0325",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Koigi vald",
+      "estleg:formerEhakCode": "0325",
+      "estleg:formerName": "Koigi vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0255"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Koigi vald (EHAK 0325) -> Järva vald (EHAK 0255); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0328",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Kolga-Jaani vald",
+      "estleg:formerEhakCode": "0328",
+      "estleg:formerName": "Kolga-Jaani vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0899"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Kolga-Jaani vald (EHAK 0328) -> Viljandi vald (EHAK 0899); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0331",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Konguta vald",
+      "estleg:formerEhakCode": "0331",
+      "estleg:formerName": "Konguta vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0171"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Konguta vald (EHAK 0331) -> Elva vald (EHAK 0171); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0334",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Koonga vald",
+      "estleg:formerEhakCode": "0334",
+      "estleg:formerName": "Koonga vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0430"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Koonga vald (EHAK 0334) -> Lääneranna vald (EHAK 0430); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0342",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Kullamaa vald",
+      "estleg:formerEhakCode": "0342",
+      "estleg:formerName": "Kullamaa vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0441"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Kullamaa vald (EHAK 0342) -> Lääne-Nigula vald (EHAK 0441); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0345",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Kunda linn",
+      "estleg:formerEhakCode": "0345",
+      "estleg:formerName": "Kunda linn",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0903"
+      },
+      "estleg:municipalityType": "linn",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Kunda linn (EHAK 0345) -> Viru-Nigula vald (EHAK 0903); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0349",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Kuressaare linn",
+      "estleg:formerEhakCode": "0349",
+      "estleg:formerName": "Kuressaare linn",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0714"
+      },
+      "estleg:municipalityType": "linn",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Kuressaare linn (EHAK 0349) -> Saaremaa vald (EHAK 0714); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0354",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Kõlleste vald",
+      "estleg:formerEhakCode": "0354",
+      "estleg:formerName": "Kõlleste vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0284"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Kõlleste vald (EHAK 0354) -> Kanepi vald (EHAK 0284); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0357",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Kõo vald",
+      "estleg:formerEhakCode": "0357",
+      "estleg:formerName": "Kõo vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0615"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Kõo vald (EHAK 0357) -> Põhja-Sakala vald (EHAK 0615); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0360",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Kõpu vald",
+      "estleg:formerEhakCode": "0360",
+      "estleg:formerName": "Kõpu vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0615"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Kõpu vald (EHAK 0360) -> Põhja-Sakala vald (EHAK 0615); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0363",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Kõue vald",
+      "estleg:formerEhakCode": "0363",
+      "estleg:formerName": "Kõue vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0338"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Kõue vald (EHAK 0363) -> Kose vald (EHAK 0338); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0368",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Käina vald",
+      "estleg:formerEhakCode": "0368",
+      "estleg:formerName": "Käina vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0205"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Käina vald (EHAK 0368) -> Hiiumaa vald (EHAK 0205); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0371",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Kärdla linn",
+      "estleg:formerEhakCode": "0371",
+      "estleg:formerName": "Kärdla linn",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0205"
+      },
+      "estleg:municipalityType": "linn",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Kärdla linn (EHAK 0371) -> Hiiumaa vald (EHAK 0205); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0373",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Kärla vald",
+      "estleg:formerEhakCode": "0373",
+      "estleg:formerName": "Kärla vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0714"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Kärla vald (EHAK 0373) -> Saaremaa vald (EHAK 0714); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0381",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Laekvere vald",
+      "estleg:formerEhakCode": "0381",
+      "estleg:formerName": "Laekvere vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0901"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Laekvere vald (EHAK 0381) -> Vinni vald (EHAK 0901); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0383",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Laeva vald",
+      "estleg:formerEhakCode": "0383",
+      "estleg:formerName": "Laeva vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0796"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Laeva vald (EHAK 0383) -> Tartu vald (EHAK 0796); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0385",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Laheda vald",
+      "estleg:formerEhakCode": "0385",
+      "estleg:formerName": "Laheda vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0622"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Laheda vald (EHAK 0385) -> Põlva vald (EHAK 0622); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0386",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Laimjala vald",
+      "estleg:formerEhakCode": "0386",
+      "estleg:formerName": "Laimjala vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0714"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Laimjala vald (EHAK 0386) -> Saaremaa vald (EHAK 0714); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0389",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Lasva vald",
+      "estleg:formerEhakCode": "0389",
+      "estleg:formerName": "Lasva vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0917"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Lasva vald (EHAK 0389) -> Võru vald (EHAK 0917); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0392",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Kõrgessaare vald",
+      "estleg:formerEhakCode": "0392",
+      "estleg:formerName": "Kõrgessaare vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0205"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Kõrgessaare vald (EHAK 0392) -> Hiiumaa vald (EHAK 0205); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0395",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Lavassaare vald",
+      "estleg:formerEhakCode": "0395",
+      "estleg:formerName": "Lavassaare vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0624"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Lavassaare vald (EHAK 0395) -> Pärnu linn (EHAK 0624); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0403",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Leisi vald",
+      "estleg:formerEhakCode": "0403",
+      "estleg:formerName": "Leisi vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0714"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Leisi vald (EHAK 0403) -> Saaremaa vald (EHAK 0714); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0411",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Lihula vald",
+      "estleg:formerEhakCode": "0411",
+      "estleg:formerName": "Lihula vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0430"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Lihula vald (EHAK 0411) -> Lääneranna vald (EHAK 0430); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0420",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Lohusuu vald",
+      "estleg:formerEhakCode": "0420",
+      "estleg:formerName": "Lohusuu vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0486"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Lohusuu vald (EHAK 0420) -> Mustvee vald (EHAK 0486); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0433",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Lääne-Saare vald",
+      "estleg:formerEhakCode": "0433",
+      "estleg:formerName": "Lääne-Saare vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0714"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Lääne-Saare vald (EHAK 0433) -> Saaremaa vald (EHAK 0714); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0449",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Maidla vald",
+      "estleg:formerEhakCode": "0449",
+      "estleg:formerName": "Maidla vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0442"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Maidla vald (EHAK 0449) -> Lüganuse vald (EHAK 0442); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0452",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Martna vald",
+      "estleg:formerEhakCode": "0452",
+      "estleg:formerName": "Martna vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0441"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Martna vald (EHAK 0452) -> Lääne-Nigula vald (EHAK 0441); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0460",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Meremäe vald",
+      "estleg:formerEhakCode": "0460",
+      "estleg:formerName": "Meremäe vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0732"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Meremäe vald (EHAK 0460) -> Setomaa vald (EHAK 0732); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0465",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Mikitamäe vald",
+      "estleg:formerEhakCode": "0465",
+      "estleg:formerName": "Mikitamäe vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0732"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Mikitamäe vald (EHAK 0465) -> Setomaa vald (EHAK 0732); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0468",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Misso vald",
+      "estleg:formerEhakCode": "0468",
+      "estleg:formerName": "Misso vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0698"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Misso vald (EHAK 0468) was split in the 2017 reform: most territory plus the administrative center (Misso village) merged into Rõuge vald (0698); southern Saatse/Lüübnitsa parishes joined Setomaa vald (0732). Choosing Rõuge vald as primary successor since the Misso vallavolikogu seat is in Rõuge territory. Wikidata records both successors via P1366."
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0473",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Mooste vald",
+      "estleg:formerEhakCode": "0473",
+      "estleg:formerName": "Mooste vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0622"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Mooste vald (EHAK 0473) -> Põlva vald (EHAK 0622); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0483",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Mustjala vald",
+      "estleg:formerEhakCode": "0483",
+      "estleg:formerName": "Mustjala vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0714"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Mustjala vald (EHAK 0483) -> Saaremaa vald (EHAK 0714); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0485",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Mustvee linn",
+      "estleg:formerEhakCode": "0485",
+      "estleg:formerName": "Mustvee linn",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0486"
+      },
+      "estleg:municipalityType": "linn",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Mustvee linn (EHAK 0485) -> Mustvee vald (EHAK 0486); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0490",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Mõisaküla linn",
+      "estleg:formerEhakCode": "0490",
+      "estleg:formerName": "Mõisaküla linn",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0480"
+      },
+      "estleg:municipalityType": "linn",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Mõisaküla linn (EHAK 0490) -> Mulgi vald (EHAK 0480); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0493",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Mõniste vald",
+      "estleg:formerEhakCode": "0493",
+      "estleg:formerName": "Mõniste vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0698"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Mõniste vald (EHAK 0493) -> Rõuge vald (EHAK 0698); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0498",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Mäetaguse vald",
+      "estleg:formerEhakCode": "0498",
+      "estleg:formerName": "Mäetaguse vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0130"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Mäetaguse vald (EHAK 0498) -> Alutaguse vald (EHAK 0130); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0501",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Mäksa vald",
+      "estleg:formerEhakCode": "0501",
+      "estleg:formerName": "Mäksa vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0291"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Mäksa vald (EHAK 0501) -> Kastre vald (EHAK 0291); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0517",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Nissi vald",
+      "estleg:formerEhakCode": "0517",
+      "estleg:formerName": "Nissi vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0726"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Nissi vald (EHAK 0517) -> Saue vald (EHAK 0726); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0520",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Noarootsi vald",
+      "estleg:formerEhakCode": "0520",
+      "estleg:formerName": "Noarootsi vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0441"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Noarootsi vald (EHAK 0520) -> Lääne-Nigula vald (EHAK 0441); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0531",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Nõva vald",
+      "estleg:formerEhakCode": "0531",
+      "estleg:formerName": "Nõva vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0441"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Nõva vald (EHAK 0531) -> Lääne-Nigula vald (EHAK 0441); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0545",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Olustvere vald",
+      "estleg:formerEhakCode": "0545",
+      "estleg:formerName": "Olustvere vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0615"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Olustvere vald (EHAK 0545) -> Põhja-Sakala vald (EHAK 0615); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0547",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Orava vald",
+      "estleg:formerEhakCode": "0547",
+      "estleg:formerName": "Orava vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0917"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Orava vald (EHAK 0547) -> Võru vald (EHAK 0917); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0550",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Orissaare vald",
+      "estleg:formerEhakCode": "0550",
+      "estleg:formerName": "Orissaare vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0714"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Orissaare vald (EHAK 0550) -> Saaremaa vald (EHAK 0714); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0562",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Padise vald",
+      "estleg:formerEhakCode": "0562",
+      "estleg:formerName": "Padise vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0431"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Padise vald (EHAK 0562) -> Lääne-Harju vald (EHAK 0431); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0565",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Paide vald",
+      "estleg:formerEhakCode": "0565",
+      "estleg:formerName": "Paide vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0567"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Paide vald (EHAK 0565) -> Paide linn (EHAK 0567); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0568",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Paikuse vald",
+      "estleg:formerEhakCode": "0568",
+      "estleg:formerName": "Paikuse vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0624"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Paikuse vald (EHAK 0568) -> Pärnu linn (EHAK 0624); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0570",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Paistu vald",
+      "estleg:formerEhakCode": "0570",
+      "estleg:formerName": "Paistu vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0899"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Paistu vald (EHAK 0570) -> Viljandi vald (EHAK 0899); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0578",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Palamuse vald",
+      "estleg:formerEhakCode": "0578",
+      "estleg:formerName": "Palamuse vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0247"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Palamuse vald (EHAK 0578) -> Jõgeva vald (EHAK 0247); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0580",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Paldiski linn",
+      "estleg:formerEhakCode": "0580",
+      "estleg:formerName": "Paldiski linn",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0431"
+      },
+      "estleg:municipalityType": "linn",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Paldiski linn (EHAK 0580) -> Lääne-Harju vald (EHAK 0431); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0582",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Palupera vald",
+      "estleg:formerEhakCode": "0582",
+      "estleg:formerName": "Palupera vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0557"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Palupera vald (EHAK 0582) was split in the 2017 reform: northern part with administrative center → Otepää vald (0557); southern part → Elva vald (0171). Choosing Otepää as primary successor since the Palupera vallavolikogu seat is in Otepää territory. Wikidata records both via P1366."
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0592",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Pihtla vald",
+      "estleg:formerEhakCode": "0592",
+      "estleg:formerName": "Pihtla vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0714"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Pihtla vald (EHAK 0592) -> Saaremaa vald (EHAK 0714); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0595",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Piirissaare vald",
+      "estleg:formerEhakCode": "0595",
+      "estleg:formerName": "Piirissaare vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0796"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Piirissaare vald (EHAK 0595) -> Tartu vald (EHAK 0796); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0600",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Karksi vald",
+      "estleg:formerEhakCode": "0600",
+      "estleg:formerName": "Karksi vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0480"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Karksi vald (EHAK 0600) -> Mulgi vald (EHAK 0480); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0605",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Puhja vald",
+      "estleg:formerEhakCode": "0605",
+      "estleg:formerName": "Puhja vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0171"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Puhja vald (EHAK 0605) -> Elva vald (EHAK 0171); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0608",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Puka vald",
+      "estleg:formerEhakCode": "0608",
+      "estleg:formerName": "Puka vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0557"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Puka vald (EHAK 0608) was split in the 2017 reform: northern part with administrative center (Puka village) → Otepää vald (0557); Aakre area → Elva vald (0171). Choosing Otepää as primary successor since the Puka vallavolikogu seat is in Otepää territory. Wikidata records both via P1366."
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0611",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Puurmani vald",
+      "estleg:formerEhakCode": "0611",
+      "estleg:formerName": "Puurmani vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0618"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Puurmani vald (EHAK 0611) -> Põltsamaa vald (EHAK 0618); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0613",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Põdrala vald",
+      "estleg:formerEhakCode": "0613",
+      "estleg:formerName": "Põdrala vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0824"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Põdrala vald (EHAK 0613) -> Tõrva vald (EHAK 0824); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0617",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Põltsamaa linn",
+      "estleg:formerEhakCode": "0617",
+      "estleg:formerName": "Põltsamaa linn",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0618"
+      },
+      "estleg:municipalityType": "linn",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Põltsamaa linn (EHAK 0617) -> Põltsamaa vald (EHAK 0618); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0620",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Põlva linn",
+      "estleg:formerEhakCode": "0620",
+      "estleg:formerName": "Põlva linn",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0622"
+      },
+      "estleg:municipalityType": "linn",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Põlva linn (EHAK 0620) -> Põlva vald (EHAK 0622); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0629",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Pärsti vald",
+      "estleg:formerEhakCode": "0629",
+      "estleg:formerName": "Pärsti vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0899"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Pärsti vald (EHAK 0629) -> Viljandi vald (EHAK 0899); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0634",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Pöide vald",
+      "estleg:formerEhakCode": "0634",
+      "estleg:formerName": "Pöide vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0714"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Pöide vald (EHAK 0634) -> Saaremaa vald (EHAK 0714); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0639",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Pühalepa vald",
+      "estleg:formerEhakCode": "0639",
+      "estleg:formerName": "Pühalepa vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0205"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Pühalepa vald (EHAK 0639) -> Hiiumaa vald (EHAK 0205); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0666",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Rannu vald",
+      "estleg:formerEhakCode": "0666",
+      "estleg:formerName": "Rannu vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0171"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Rannu vald (EHAK 0666) -> Elva vald (EHAK 0171); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0674",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Ridala vald",
+      "estleg:formerEhakCode": "0674",
+      "estleg:formerName": "Ridala vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0184"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Ridala vald (EHAK 0674) -> Haapsalu linn (EHAK 0184); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0684",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Roosna-Alliku vald",
+      "estleg:formerEhakCode": "0684",
+      "estleg:formerName": "Roosna-Alliku vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0567"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Roosna-Alliku vald (EHAK 0684) -> Paide linn (EHAK 0567); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0694",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Rõngu vald",
+      "estleg:formerEhakCode": "0694",
+      "estleg:formerName": "Rõngu vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0171"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Rõngu vald (EHAK 0694) -> Elva vald (EHAK 0171); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0702",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Rägavere vald",
+      "estleg:formerEhakCode": "0702",
+      "estleg:formerName": "Rägavere vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0901"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Rägavere vald (EHAK 0702) -> Vinni vald (EHAK 0901); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0713",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Saare vald",
+      "estleg:formerEhakCode": "0713",
+      "estleg:formerName": "Saare vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0486"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Saare vald (EHAK 0713) -> Mustvee vald (EHAK 0486); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0715",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Saarepeedi vald",
+      "estleg:formerEhakCode": "0715",
+      "estleg:formerName": "Saarepeedi vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0899"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Saarepeedi vald (EHAK 0715) -> Viljandi vald (EHAK 0899); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0721",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Salme vald",
+      "estleg:formerEhakCode": "0721",
+      "estleg:formerName": "Salme vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0714"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Salme vald (EHAK 0721) -> Saaremaa vald (EHAK 0714); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0724",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Sangaste vald",
+      "estleg:formerEhakCode": "0724",
+      "estleg:formerName": "Sangaste vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0557"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Sangaste vald (EHAK 0724) -> Otepää vald (EHAK 0557); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0728",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Saue linn",
+      "estleg:formerEhakCode": "0728",
+      "estleg:formerName": "Saue linn",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0726"
+      },
+      "estleg:municipalityType": "linn",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Saue linn (EHAK 0728) -> Saue vald (EHAK 0726); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0730",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Sauga vald",
+      "estleg:formerEhakCode": "0730",
+      "estleg:formerName": "Sauga vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0809"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Sauga vald (EHAK 0730) -> Tori vald (EHAK 0809); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0741",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Sindi linn",
+      "estleg:formerEhakCode": "0741",
+      "estleg:formerName": "Sindi linn",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0809"
+      },
+      "estleg:municipalityType": "linn",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Sindi linn (EHAK 0741) -> Tori vald (EHAK 0809); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0756",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Surju vald",
+      "estleg:formerEhakCode": "0756",
+      "estleg:formerName": "Surju vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0712"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Surju vald (EHAK 0756) -> Saarde vald (EHAK 0712); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0758",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Suure-Jaani vald",
+      "estleg:formerEhakCode": "0758",
+      "estleg:formerName": "Suure-Jaani vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0615"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Suure-Jaani vald (EHAK 0758) -> Põhja-Sakala vald (EHAK 0615); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0760",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Suure-Jaani linn",
+      "estleg:formerEhakCode": "0760",
+      "estleg:formerName": "Suure-Jaani linn",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0615"
+      },
+      "estleg:municipalityType": "linn",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Suure-Jaani linn (EHAK 0760) -> Põhja-Sakala vald (EHAK 0615); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0767",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Sõmerpalu vald",
+      "estleg:formerEhakCode": "0767",
+      "estleg:formerName": "Sõmerpalu vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0917"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Sõmerpalu vald (EHAK 0767) -> Võru vald (EHAK 0917); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0770",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Sõmeru vald",
+      "estleg:formerEhakCode": "0770",
+      "estleg:formerName": "Sõmeru vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0661"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Sõmeru vald (EHAK 0770) -> Rakvere vald (EHAK 0661); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0773",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Tabivere vald",
+      "estleg:formerEhakCode": "0773",
+      "estleg:formerName": "Tabivere vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0796"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Tabivere vald (EHAK 0773) -> Tartu vald (EHAK 0796); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0779",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Taheva vald",
+      "estleg:formerEhakCode": "0779",
+      "estleg:formerName": "Taheva vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0855"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Taheva vald (EHAK 0779) -> Valga vald (EHAK 0855); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0786",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Tamsalu vald",
+      "estleg:formerEhakCode": "0786",
+      "estleg:formerName": "Tamsalu vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0792"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Tamsalu vald (EHAK 0786) -> Tapa vald (EHAK 0792); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0797",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Tarvastu vald",
+      "estleg:formerEhakCode": "0797",
+      "estleg:formerName": "Tarvastu vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0899"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Tarvastu vald (EHAK 0797) -> Viljandi vald (EHAK 0899); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0805",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Tootsi vald",
+      "estleg:formerEhakCode": "0805",
+      "estleg:formerName": "Tootsi vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0638"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Tootsi vald (EHAK 0805) -> Põhja-Pärnumaa vald (EHAK 0638); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0807",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Torgu vald",
+      "estleg:formerEhakCode": "0807",
+      "estleg:formerName": "Torgu vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0714"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Torgu vald (EHAK 0807) -> Saaremaa vald (EHAK 0714); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0810",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Torma vald",
+      "estleg:formerEhakCode": "0810",
+      "estleg:formerName": "Torma vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0247"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Torma vald (EHAK 0810) -> Jõgeva vald (EHAK 0247); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0815",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Tudulinna vald",
+      "estleg:formerEhakCode": "0815",
+      "estleg:formerName": "Tudulinna vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0130"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Tudulinna vald (EHAK 0815) -> Alutaguse vald (EHAK 0130); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0820",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Tõlliste vald",
+      "estleg:formerEhakCode": "0820",
+      "estleg:formerName": "Tõlliste vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0855"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Tõlliste vald (EHAK 0820) -> Valga vald (EHAK 0855); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0823",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Tõrva linn",
+      "estleg:formerEhakCode": "0823",
+      "estleg:formerName": "Tõrva linn",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0824"
+      },
+      "estleg:municipalityType": "linn",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Tõrva linn (EHAK 0823) -> Tõrva vald (EHAK 0824); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0826",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Tõstamaa vald",
+      "estleg:formerEhakCode": "0826",
+      "estleg:formerName": "Tõstamaa vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0624"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Tõstamaa vald (EHAK 0826) -> Pärnu linn (EHAK 0624); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0831",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Tähtvere vald",
+      "estleg:formerEhakCode": "0831",
+      "estleg:formerName": "Tähtvere vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0793"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Tähtvere vald (EHAK 0831) -> Tartu linn (EHAK 0793); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0843",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Urvaste vald",
+      "estleg:formerEhakCode": "0843",
+      "estleg:formerName": "Urvaste vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0142"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Urvaste vald (EHAK 0843) -> Antsla vald (EHAK 0142); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0848",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Tahkuranna vald",
+      "estleg:formerEhakCode": "0848",
+      "estleg:formerName": "Tahkuranna vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0214"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Tahkuranna vald (EHAK 0848) -> Häädemeeste vald (EHAK 0214); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0851",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Vaivara vald",
+      "estleg:formerEhakCode": "0851",
+      "estleg:formerName": "Vaivara vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0514"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Vaivara vald (EHAK 0851) -> Narva-Jõesuu linn (EHAK 0514); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0854",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Valga linn",
+      "estleg:formerEhakCode": "0854",
+      "estleg:formerName": "Valga linn",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0855"
+      },
+      "estleg:municipalityType": "linn",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Valga linn (EHAK 0854) -> Valga vald (EHAK 0855); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0856",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Valgjärve vald",
+      "estleg:formerEhakCode": "0856",
+      "estleg:formerName": "Valgjärve vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0284"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Valgjärve vald (EHAK 0856) -> Kanepi vald (EHAK 0284); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0858",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Valjala vald",
+      "estleg:formerEhakCode": "0858",
+      "estleg:formerName": "Valjala vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0714"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Valjala vald (EHAK 0858) -> Saaremaa vald (EHAK 0714); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0861",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Vara vald",
+      "estleg:formerEhakCode": "0861",
+      "estleg:formerName": "Vara vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0586"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Vara vald (EHAK 0861) -> Peipsiääre vald (EHAK 0586); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0863",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Varbla vald",
+      "estleg:formerEhakCode": "0863",
+      "estleg:formerName": "Varbla vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0430"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Varbla vald (EHAK 0863) -> Lääneranna vald (EHAK 0430); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0865",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Varstu vald",
+      "estleg:formerEhakCode": "0865",
+      "estleg:formerName": "Varstu vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0698"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Varstu vald (EHAK 0865) -> Rõuge vald (EHAK 0698); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0868",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Vasalemma vald",
+      "estleg:formerEhakCode": "0868",
+      "estleg:formerName": "Vasalemma vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0431"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Vasalemma vald (EHAK 0868) -> Lääne-Harju vald (EHAK 0431); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0872",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Vastse-Kuuste vald",
+      "estleg:formerEhakCode": "0872",
+      "estleg:formerName": "Vastse-Kuuste vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0622"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Vastse-Kuuste vald (EHAK 0872) -> Põlva vald (EHAK 0622); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0874",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Vastseliina vald",
+      "estleg:formerEhakCode": "0874",
+      "estleg:formerName": "Vastseliina vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0917"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Vastseliina vald (EHAK 0874) -> Võru vald (EHAK 0917); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0884",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Vigala vald",
+      "estleg:formerEhakCode": "0884",
+      "estleg:formerName": "Vigala vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0503"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Vigala vald (EHAK 0884) -> Märjamaa vald (EHAK 0503); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0887",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Vihula vald",
+      "estleg:formerEhakCode": "0887",
+      "estleg:formerName": "Vihula vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0191"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Vihula vald (EHAK 0887) -> Haljala vald (EHAK 0191); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0892",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Viiratsi vald",
+      "estleg:formerEhakCode": "0892",
+      "estleg:formerName": "Viiratsi vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0899"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Viiratsi vald (EHAK 0892) -> Viljandi vald (EHAK 0899); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0912",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Võhma linn",
+      "estleg:formerEhakCode": "0912",
+      "estleg:formerName": "Võhma linn",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0615"
+      },
+      "estleg:municipalityType": "linn",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Võhma linn (EHAK 0912) -> Põhja-Sakala vald (EHAK 0615); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0915",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Võnnu vald",
+      "estleg:formerEhakCode": "0915",
+      "estleg:formerName": "Võnnu vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0291"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Võnnu vald (EHAK 0915) -> Kastre vald (EHAK 0291); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0929",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Vändra vald",
+      "estleg:formerEhakCode": "0929",
+      "estleg:formerName": "Vändra vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0638"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Vändra vald (EHAK 0929) -> Põhja-Pärnumaa vald (EHAK 0638); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0934",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Värska vald",
+      "estleg:formerEhakCode": "0934",
+      "estleg:formerName": "Värska vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0732"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Värska vald (EHAK 0934) -> Setomaa vald (EHAK 0732); per RT I 21.06.2017 1"
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality_0949",
+      "@type": [
+        "owl:NamedIndividual",
+        "estleg:HistoricalMunicipality"
+      ],
+      "rdfs:label": "Ülenurme vald",
+      "estleg:formerEhakCode": "0949",
+      "estleg:formerName": "Ülenurme vald",
+      "estleg:succeededBy": {
+        "@id": "estleg:Municipality_EHAK_0283"
+      },
+      "estleg:municipalityType": "vald",
+      "estleg:mergedAt": {
+        "@value": "2017-10-15",
+        "@type": "xsd:date"
+      },
+      "estleg:mergerEvidence": "Wikidata: Ülenurme vald (EHAK 0949) -> Kambja vald (EHAK 0283); per RT I 21.06.2017 1"
+    }
+  ]
+}

--- a/krr_outputs/controlled_vocabulary.jsonld
+++ b/krr_outputs/controlled_vocabulary.jsonld
@@ -2147,6 +2147,88 @@
       "rdfs:range": {
         "@id": "xsd:string"
       }
+    },
+    {
+      "@id": "estleg:Municipality",
+      "@type": [
+        "owl:Class"
+      ],
+      "rdfs:label": "Municipality",
+      "rdfs:comment": "Reusable class materialized for vocabulary coverage validation. A current Estonian municipality (KOV unit) — a territorial entity identified by its EHAK code; the canonical definition lives in metadata.jsonld. Re-asserted here so estleg:succeededBy's rdfs:range (and the metadata.jsonld estleg:currentMunicipality / estleg:enactedByMunicipality ranges) resolve within the published corpus."
+    },
+    {
+      "@id": "estleg:HistoricalMunicipality",
+      "@type": [
+        "owl:Class"
+      ],
+      "rdfs:label": "Historical Municipality",
+      "rdfs:comment": "A former Estonian municipality (KOV unit) that was merged or abolished by a territorial reform — chiefly the 2017 haldusreform. Modelled as a distinct node (IRI scheme estleg:HistoricalMunicipality_<formerEhakCode>) carrying its pre-merger EHAK code, pre-merger name, and an estleg:succeededBy link to the surviving current municipality, so KOV acts can be queried by issuing-time jurisdiction rather than only by present-day successor. Deliberately NOT a subclass of estleg:Municipality (the latter's SHACL shape constrains the Municipality_EHAK_<code> IRI form and requires estleg:ehakCode/estleg:county, which do not apply to abolished units). Introduced for issue #130; nodes are derived from the issuer registry's mappingEvidence citations."
+    },
+    {
+      "@id": "estleg:formerEhakCode",
+      "@type": [
+        "owl:DatatypeProperty"
+      ],
+      "rdfs:label": "Former EHAK Code",
+      "rdfs:comment": "The pre-merger four-digit EHAK code of an estleg:HistoricalMunicipality (e.g. \"0105\" for the former Abja vald). Distinct from estleg:ehakCode, which carries the still-current code on estleg:Municipality nodes.",
+      "rdfs:range": {
+        "@id": "xsd:string"
+      }
+    },
+    {
+      "@id": "estleg:formerName",
+      "@type": [
+        "owl:DatatypeProperty"
+      ],
+      "rdfs:label": "Former Name",
+      "rdfs:comment": "The pre-merger name of an estleg:HistoricalMunicipality, including the unit-type word (e.g. \"Abja vald\", \"Kallaste linn\"). Diacritic-correct — sourced from the merger-evidence citation, not the diacritic-stripped issuer slug.",
+      "rdfs:range": {
+        "@id": "xsd:string"
+      }
+    },
+    {
+      "@id": "estleg:succeededBy",
+      "@type": [
+        "owl:ObjectProperty"
+      ],
+      "rdfs:label": "Succeeded By",
+      "rdfs:comment": "Links an estleg:HistoricalMunicipality to the current estleg:Municipality that succeeded it after a territorial reform (the surviving EHAK unit). Where a former municipality was split across several successors, this points at the primary successor (the one holding the former administrative centre); the full set is recorded in estleg:mergerEvidence.",
+      "rdfs:range": {
+        "@id": "estleg:Municipality"
+      }
+    },
+    {
+      "@id": "estleg:mergedAt",
+      "@type": [
+        "owl:DatatypeProperty"
+      ],
+      "rdfs:label": "Merged At",
+      "rdfs:comment": "The date on which an estleg:HistoricalMunicipality ceased to exist as an independent unit (the merger/abolition effective date). For 2017-haldusreform units this is 2017-10-15, the day the post-election councils of the merged municipalities convened. Omitted when the effective date cannot be determined from the source evidence.",
+      "rdfs:range": {
+        "@id": "xsd:date"
+      }
+    },
+    {
+      "@id": "estleg:mergerEvidence",
+      "@type": [
+        "owl:DatatypeProperty"
+      ],
+      "rdfs:label": "Merger Evidence",
+      "rdfs:comment": "Free-text citation supporting an estleg:HistoricalMunicipality's pre-merger identity and its successor mapping (e.g. \"Wikidata: Abja vald (EHAK 0105) -> Mulgi vald (EHAK 0480); per RT I 21.06.2017 1\"). Carried verbatim from the issuer registry's mappingEvidence — the auditable trail.",
+      "rdfs:range": {
+        "@id": "xsd:string"
+      }
+    },
+    {
+      "@id": "estleg:municipalityType",
+      "@type": [
+        "owl:DatatypeProperty"
+      ],
+      "rdfs:label": "Municipality Type",
+      "rdfs:comment": "The Estonian local-government unit type of an estleg:HistoricalMunicipality. SHACL constrains it to one of: \"vald\" (rural municipality) or \"linn\" (town/city). Derived from the unit-type word in the pre-merger name; omitted if not derivable.",
+      "rdfs:range": {
+        "@id": "xsd:string"
+      }
     }
   ]
 }

--- a/scripts/enrich_kov_layer1.py
+++ b/scripts/enrich_kov_layer1.py
@@ -25,8 +25,10 @@ from pathlib import Path
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 
 from kov_registry import (
+    HistoricalMunicipality,
     IssuerEntry,
     Municipality,
+    extract_historical_municipalities,
     load_municipalities,
     normalize_title,
     parse_issuer_slug,
@@ -39,6 +41,12 @@ KOV_DIR = KRR_DIR / "regulations" / "kov"
 
 MUNICIPALITIES_OUT = KRR_DIR / "municipalities_peep.json"
 ISSUERS_OUT = KRR_DIR / "issuers_kov_peep.json"
+# Historical (pre-merger) municipality nodes — issue #130. Written under
+# data/ehak/ (alongside municipalities.json / issuers.json, the source
+# KOV registry files) rather than krr_outputs/ so it does not bump the
+# krr_outputs/ file-count statistics validated against metadata.jsonld.
+# It is added to the `kov` SHACL bucket in shacl_validate_all.py.
+HISTORICAL_MUNICIPALITIES_OUT = EHAK_DIR / "historical_municipalities.jsonld"
 
 # >5 missing law files in INDEX.json indicates real corpus drift,
 # not the occasional stale entry. Hard-fail in that case so the
@@ -64,6 +72,10 @@ def municipality_iri(ehak_code: str) -> str:
 
 def issuer_iri(slug: str) -> str:
     return f"estleg:Issuer_{slug}"
+
+
+def historical_municipality_iri(former_ehak_code: str) -> str:
+    return f"estleg:HistoricalMunicipality_{former_ehak_code}"
 
 
 def build_municipality_doc(municipalities: dict[str, Municipality]) -> dict:
@@ -113,6 +125,63 @@ def build_issuer_doc(issuers: dict[str, IssuerEntry]) -> dict:
             node["estleg:mappingEvidence"] = entry["mappingEvidence"]
         if entry["historicalMunicipalityName"]:
             node["estleg:historicalMunicipalityName"] = entry["historicalMunicipalityName"]
+        nodes.append(node)
+    return {"@context": CONTEXT, "@graph": nodes}
+
+
+def build_historical_municipality_doc(
+    historical: dict[str, HistoricalMunicipality],
+) -> dict:
+    """Build the JSON-LD document containing all HistoricalMunicipality nodes.
+
+    One node per distinct pre-merger EHAK code (deduped across the
+    multiple issuers that map to it). Each node carries
+    ``estleg:formerEhakCode`` / ``estleg:formerName`` /
+    ``estleg:succeededBy`` (always), plus ``estleg:mergedAt`` /
+    ``estleg:mergerEvidence`` / ``estleg:municipalityType`` where
+    derivable. Nodes are emitted in ascending former-EHAK order for a
+    stable on-disk diff. The ``issuerSlugs`` carried on the in-memory
+    :class:`HistoricalMunicipality` records are used for coverage
+    reporting only and are not serialised onto the nodes — the
+    issuer→historical relationship remains via the issuer node's
+    ``estleg:historicalMunicipalityName`` literal, unchanged here.
+    """
+    nodes: list[dict] = [
+        {
+            "@id": "estleg:HistoricalMunicipalities_Map_2026",
+            "@type": ["owl:Ontology"],
+            "rdfs:label": "Estonian Historical Municipalities (pre-merger KOV units)",
+            "rdfs:comment": (
+                "Former Estonian municipalities abolished by territorial "
+                "reform (chiefly the 2017 haldusreform). Each node links "
+                "to its surviving successor via estleg:succeededBy. "
+                "Derived from the issuer registry's mappingEvidence "
+                "citations; see issue #130."
+            ),
+            "dcterms:source": {"@id": "https://data.riik.ee/ontology/estleg#Issuers_Kov_Map_2026"},
+        }
+    ]
+    for code in sorted(historical):
+        hist = historical[code]
+        node: dict = {
+            "@id": historical_municipality_iri(code),
+            "@type": ["owl:NamedIndividual", "estleg:HistoricalMunicipality"],
+            "rdfs:label": hist["formerName"],
+            "estleg:formerEhakCode": code,
+            "estleg:formerName": hist["formerName"],
+            "estleg:succeededBy": {
+                "@id": municipality_iri(hist["succeededByCode"])
+            },
+        }
+        if hist.get("municipalityType"):
+            node["estleg:municipalityType"] = hist["municipalityType"]
+        if hist.get("mergedAt"):
+            node["estleg:mergedAt"] = {
+                "@value": hist["mergedAt"],
+                "@type": "xsd:date",
+            }
+        if hist.get("mergerEvidence"):
+            node["estleg:mergerEvidence"] = hist["mergerEvidence"]
         nodes.append(node)
     return {"@context": CONTEXT, "@graph": nodes}
 
@@ -440,6 +509,24 @@ def main(argv: list[str] | None = None) -> int:
     # 2. Write Issuer JSON-LD
     _save_jsonld(ISSUERS_OUT, build_issuer_doc(issuers))
     print(f"Wrote {ISSUERS_OUT.name}")
+
+    # 2b. Write HistoricalMunicipality JSON-LD (issue #130). Derived
+    #     from the issuer registry's mappingEvidence citations; one node
+    #     per distinct pre-merger EHAK code, deduped across issuers.
+    #     Path is resolved from the (monkeypatchable) EHAK_DIR so test
+    #     trees that patch EHAK_DIR don't write into the real repo.
+    historical_out = EHAK_DIR / HISTORICAL_MUNICIPALITIES_OUT.name
+    historical = extract_historical_municipalities(
+        list(issuers.values()), municipalities,
+    )
+    _save_jsonld(
+        historical_out,
+        build_historical_municipality_doc(historical),
+    )
+    print(
+        f"Wrote {historical_out.name} "
+        f"({len(historical)} HistoricalMunicipality nodes)"
+    )
 
     # 3. Enrich KOV act files
     kov_files = sorted(KOV_DIR.glob("**/*_peep.json"))

--- a/scripts/kov_registry.py
+++ b/scripts/kov_registry.py
@@ -409,3 +409,157 @@ def load_curated_map(path: Path) -> dict[str, CuratedRow]:
                 "mappingEvidence": evidence,
             }
     return out
+
+
+# ---------------------------------------------------------------------------
+# Historical (pre-merger) municipality extraction — issue #130
+# ---------------------------------------------------------------------------
+#
+# The issuer registry already records, for every legacy KOV body, the
+# surviving municipality it maps to plus a `mappingEvidence` citation
+# that embeds the *pre-merger* EHAK code and name. The vast majority of
+# the corpus comes from the 2017 haldusreform (`mappingSource ==
+# "haldusreform-2017"`), whose evidence strings look like:
+#
+#   Wikidata: Abja vald (EHAK 0105) -> Mulgi vald (EHAK 0480); per RT I 21.06.2017 1
+#
+# A handful of split-municipality cases are `mappingSource ==
+# "manual-review"` with prose evidence that still opens with
+# `<Old name> vald (EHAK <old code>)`:
+#
+#   Misso vald (EHAK 0468) was split in the 2017 reform: ...
+#
+# Both shapes are matched by `_HISTORICAL_EVIDENCE_RE` (the first
+# `<Name> <vald|linn> (EHAK <code>)` occurrence — for the haldusreform
+# arrow form that is the left-hand side, i.e. the predecessor). Issuers
+# with `mappingSource == "auto-match"` map to a still-current
+# municipality and contribute no historical node.
+#
+# The 2017 haldusreform local-government reorganisation took legal
+# effect on the day the new councils convened after the 15 October 2017
+# local elections, i.e. 2017-10-15 — used as `mergedAt` for every
+# `haldusreform-2017` (and the manual-review 2017-split) entry. Other
+# `mappingSource` values would need their own date handling; none exist
+# in the corpus today, so an unrecognised source simply omits
+# `mergedAt` (the JSON-LD builder leaves the key off).
+
+_HISTORICAL_EVIDENCE_RE = re.compile(
+    r"(?P<name>[A-ZÄÖÜÕ][A-Za-zÄÖÜÕäöüõ.\-]*"
+    r"(?:[ /][A-ZÄÖÜÕ][A-Za-zÄÖÜÕäöüõ.\-]*)*)"
+    r"\s+(?P<type>vald|linn)\s+\(EHAK\s+(?P<code>\d{4})\)"
+)
+
+# Mapping sources whose entries describe a 2017-haldusreform merger.
+_HALDUSREFORM_2017_SOURCES = frozenset({"haldusreform-2017", "manual-review"})
+HALDUSREFORM_2017_MERGE_DATE = "2017-10-15"
+
+
+class HistoricalMunicipality(TypedDict):
+    formerEhakCode: str          # pre-merger EHAK code, 4 digits
+    formerName: str              # diacritic-correct pre-merger name, e.g. "Abja vald"
+    municipalityType: Literal["vald", "linn"]
+    succeededByCode: str         # surviving municipality EHAK code
+    mergedAt: str | None         # merger effective date (xsd:date) or None
+    mergerEvidence: str          # citation string from mappingEvidence
+    issuerSlugs: list[str]       # legacy issuer slugs that map to this unit (sorted)
+
+
+def _merge_date_for_source(source: str) -> str | None:
+    """Return the merger effective date for a given `mappingSource`.
+
+    The 2017 haldusreform took effect 2017-10-15; that covers every
+    ``haldusreform-2017`` entry and the small set of ``manual-review``
+    rows (all of which are 2017-reform splits — their evidence cites
+    "the 2017 reform"). Any other source returns ``None`` so the
+    builder omits ``estleg:mergedAt`` rather than guessing a date.
+    """
+    if source in _HALDUSREFORM_2017_SOURCES:
+        return HALDUSREFORM_2017_MERGE_DATE
+    return None
+
+
+def extract_historical_municipalities(
+    issuers: list[IssuerEntry],
+    municipalities: dict[str, Municipality] | None = None,
+) -> dict[str, HistoricalMunicipality]:
+    """Derive distinct pre-merger municipalities from the issuer registry.
+
+    For every issuer whose ``mappingEvidence`` embeds a predecessor
+    ``<Name> <vald|linn> (EHAK <code>)`` reference, produce one
+    :class:`HistoricalMunicipality` keyed by the pre-merger EHAK code.
+    Multiple issuers (e.g. a vallavolikogu and a vallavalitsus) that
+    map to the same historical unit are de-duplicated; their slugs are
+    collected (sorted) under ``issuerSlugs``.
+
+    ``municipalities``, when provided, is used to validate that every
+    derived ``succeededByCode`` resolves to a real current
+    municipality — a mismatch raises ``ValueError`` (a corpus/CSV drift
+    signal) rather than silently emitting a dangling successor link.
+    Pass ``None`` to skip that check (e.g. in unit tests with synthetic
+    issuer rows).
+
+    Issuers with ``mappingSource == "auto-match"`` (or any other
+    evidence shape that lacks a parseable predecessor reference) are
+    skipped — they map directly to a still-current municipality.
+
+    Determinism: the returned dict is built by iterating ``issuers`` in
+    input order, but every list value (``issuerSlugs``) is sorted, and
+    callers that serialise the result should iterate ``sorted(...)`` on
+    the keys (the JSON-LD builder does).
+    """
+    out: dict[str, HistoricalMunicipality] = {}
+    for entry in issuers:
+        evidence = (entry.get("mappingEvidence") or "").strip()
+        if not evidence:
+            continue
+        match = _HISTORICAL_EVIDENCE_RE.search(evidence)
+        if match is None:
+            continue
+        former_code = match.group("code")
+        current_code = entry["currentMunicipalityCode"]
+        if former_code == current_code:
+            # Evidence cites the *current* code first (unexpected for
+            # the known shapes) — not a predecessor, skip rather than
+            # invent a self-succession edge.
+            continue
+        former_name = " ".join(match.group("name").split())
+        mun_type = match.group("type")
+        slug = entry["slug"]
+        existing = out.get(former_code)
+        if existing is None:
+            out[former_code] = {
+                "formerEhakCode": former_code,
+                "formerName": f"{former_name} {mun_type}",
+                "municipalityType": mun_type,  # type: ignore[typeddict-item]
+                "succeededByCode": current_code,
+                "mergedAt": _merge_date_for_source(entry["mappingSource"]),
+                "mergerEvidence": evidence,
+                "issuerSlugs": [slug],
+            }
+        else:
+            # Same historical unit reached via another issuer. The
+            # successor code / name / type must agree — divergence is a
+            # data bug worth surfacing.
+            if existing["succeededByCode"] != current_code:
+                raise ValueError(
+                    f"historical municipality EHAK {former_code} "
+                    f"({former_name}) has conflicting successors: "
+                    f"{existing['succeededByCode']!r} (via "
+                    f"{existing['issuerSlugs'][0]!r}) vs {current_code!r} "
+                    f"(via {slug!r})"
+                )
+            if slug not in existing["issuerSlugs"]:
+                existing["issuerSlugs"].append(slug)
+                existing["issuerSlugs"].sort()
+
+    if municipalities is not None:
+        for code, hist in out.items():
+            succ = hist["succeededByCode"]
+            if succ not in municipalities:
+                raise ValueError(
+                    f"historical municipality EHAK {code} "
+                    f"({hist['formerName']}) is succeeded by EHAK "
+                    f"{succ!r}, which is not a current municipality in "
+                    "municipalities.json — registry/CSV drift."
+                )
+    return out

--- a/scripts/shacl_validate_all.py
+++ b/scripts/shacl_validate_all.py
@@ -35,9 +35,16 @@ def collect_laws(krr: Path = KRR) -> list[Path]:
 
 
 def collect_kov(krr: Path = KRR) -> list[Path]:
+    # ``data/ehak/historical_municipalities.jsonld`` (issue #130) lives
+    # under the source KOV registry directory rather than ``krr_outputs/``
+    # (to keep it out of the krr_outputs/ file-count statistics that are
+    # validated against ``metadata.jsonld``), so it has to be listed here
+    # explicitly — the ``regulations/kov/**`` glob below does not reach it.
+    repo_root = krr.parent
     out = [
         krr / "municipalities_peep.json",
         krr / "issuers_kov_peep.json",
+        repo_root / "data" / "ehak" / "historical_municipalities.jsonld",
         *collect_controlled_vocabulary(krr),
     ]
     out.extend(sorted((krr / "regulations" / "kov").glob("**/*_peep.json")))

--- a/shacl/estonian_legal_shapes.ttl
+++ b/shacl/estonian_legal_shapes.ttl
@@ -1107,6 +1107,80 @@ estleg:IssuerShape
         sh:datatype xsd:string ;
     ] .
 
+# HistoricalMunicipalityShape — pre-merger KOV units (issue #130).
+#
+# A former Estonian municipality merged/abolished by a territorial
+# reform (chiefly the 2017 haldusreform). One node per distinct
+# pre-merger EHAK code, IRI form
+# estleg:HistoricalMunicipality_<formerEhakCode>. estleg:succeededBy
+# points at the surviving current municipality; it is only constrained
+# to be an IRI here (not sh:class estleg:Municipality) — the live `kov`
+# SHACL bucket also loads municipalities_peep.json so the link does
+# resolve, but the IRI-only constraint keeps this shape independent of
+# RDFS subclass inference, mirroring the convention used elsewhere in
+# this file (CitationShape / AnnotationShape). estleg:municipalityType,
+# when present, is one of "vald" | "linn".
+estleg:HistoricalMunicipalityShape
+    a sh:NodeShape ;
+    sh:targetClass estleg:HistoricalMunicipality ;
+    sh:nodeKind sh:IRI ;
+    sh:pattern "^https://data\\.riik\\.ee/ontology/estleg#HistoricalMunicipality_[0-9]{4}$" ;
+    sh:property [
+        sh:path estleg:formerEhakCode ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:string ;
+        sh:pattern "^[0-9]{4}$" ;
+        sh:name "formerEhakCode" ;
+        sh:description "The pre-merger four-digit EHAK code." ;
+    ] ;
+    sh:property [
+        sh:path estleg:formerName ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:string ;
+        sh:name "formerName" ;
+        sh:description "The pre-merger name including the unit-type word (e.g. \"Abja vald\")." ;
+    ] ;
+    sh:property [
+        sh:path estleg:succeededBy ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:IRI ;
+        sh:name "succeededBy" ;
+        sh:description "The current estleg:Municipality (an IRI) that succeeded this unit." ;
+    ] ;
+    sh:property [
+        sh:path estleg:mergedAt ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:date ;
+        sh:name "mergedAt" ;
+        sh:description "The merger/abolition effective date (2017-10-15 for haldusreform-2017 units). Absent ⇒ date undetermined." ;
+    ] ;
+    sh:property [
+        sh:path estleg:mergerEvidence ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:string ;
+        sh:name "mergerEvidence" ;
+        sh:description "Free-text citation supporting the pre-merger identity and the successor mapping." ;
+    ] ;
+    sh:property [
+        sh:path estleg:municipalityType ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:string ;
+        sh:in ( "vald" "linn" ) ;
+        sh:name "municipalityType" ;
+        sh:description "The Estonian local-government unit type: \"vald\" or \"linn\"." ;
+    ] ;
+    sh:property [
+        sh:path rdfs:label ;
+        sh:minCount 1 ;
+        sh:datatype xsd:string ;
+    ] .
+
 estleg:MunicipalRegulationLayer1Shape
     a sh:NodeShape ;
     sh:targetClass estleg:MunicipalRegulation ;

--- a/tests/test_historical_municipalities.py
+++ b/tests/test_historical_municipalities.py
@@ -1,0 +1,337 @@
+"""Tests for the HistoricalMunicipality model — issue #130.
+
+Covers:
+  * ``build_historical_municipality_doc`` (the JSON-LD builder in
+    ``enrich_kov_layer1.py``),
+  * the new controlled-vocabulary terms,
+  * the ``estleg:HistoricalMunicipalityShape`` SHACL shape,
+  * regen-drift of the committed ``data/ehak/historical_municipalities.jsonld``.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import pytest
+
+from enrich_kov_layer1 import (
+    build_historical_municipality_doc,
+    historical_municipality_iri,
+)
+from kov_registry import extract_historical_municipalities, load_municipalities
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SHAPES = REPO_ROOT / "shacl" / "estonian_legal_shapes.ttl"
+EHAK_DIR = REPO_ROOT / "data" / "ehak"
+HISTORICAL_OUT = EHAK_DIR / "historical_municipalities.jsonld"
+CONTROLLED_VOCAB = REPO_ROOT / "krr_outputs" / "controlled_vocabulary.jsonld"
+
+CONTEXT = {
+    "estleg": "https://data.riik.ee/ontology/estleg#",
+    "owl": "http://www.w3.org/2002/07/owl#",
+    "rdf": "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "rdfs": "http://www.w3.org/2000/01/rdf-schema#",
+    "xsd": "http://www.w3.org/2001/XMLSchema#",
+    "dcterms": "http://purl.org/dc/terms/",
+}
+
+
+# A representative historical-municipality record (the in-memory shape
+# `extract_historical_municipalities` produces).
+def _hist_record(
+    *,
+    former_code: str = "0105",
+    former_name: str = "Abja vald",
+    municipality_type: str = "vald",
+    succ_code: str = "0480",
+    merged_at: str | None = "2017-10-15",
+    evidence: str = (
+        "Wikidata: Abja vald (EHAK 0105) -> Mulgi vald (EHAK 0480); "
+        "per RT I 21.06.2017 1"
+    ),
+    issuer_slugs: list[str] | None = None,
+) -> dict:
+    return {
+        "formerEhakCode": former_code,
+        "formerName": former_name,
+        "municipalityType": municipality_type,
+        "succeededByCode": succ_code,
+        "mergedAt": merged_at,
+        "mergerEvidence": evidence,
+        "issuerSlugs": issuer_slugs or ["abja_vallavolikogu"],
+    }
+
+
+class TestBuildHistoricalMunicipalityDoc:
+    def test_builds_jsonld_doc_with_ontology_header(self):
+        doc = build_historical_municipality_doc({"0105": _hist_record()})
+        assert doc["@context"]["estleg"] == "https://data.riik.ee/ontology/estleg#"
+        graph = doc["@graph"]
+        # First node is the owl:Ontology header.
+        assert graph[0]["@id"] == "estleg:HistoricalMunicipalities_Map_2026"
+        assert "owl:Ontology" in graph[0]["@type"]
+
+    def test_node_has_required_fields(self):
+        doc = build_historical_municipality_doc({"0105": _hist_record()})
+        node = next(
+            n for n in doc["@graph"]
+            if n["@id"] == "estleg:HistoricalMunicipality_0105"
+        )
+        assert "estleg:HistoricalMunicipality" in node["@type"]
+        assert "owl:NamedIndividual" in node["@type"]
+        assert node["rdfs:label"] == "Abja vald"
+        assert node["estleg:formerEhakCode"] == "0105"
+        assert node["estleg:formerName"] == "Abja vald"
+        assert node["estleg:succeededBy"] == {"@id": "estleg:Municipality_EHAK_0480"}
+        assert node["estleg:municipalityType"] == "vald"
+        assert node["estleg:mergedAt"] == {"@value": "2017-10-15", "@type": "xsd:date"}
+        assert "EHAK 0105" in node["estleg:mergerEvidence"]
+
+    def test_iri_scheme(self):
+        assert historical_municipality_iri("0105") == "estleg:HistoricalMunicipality_0105"
+
+    def test_optional_fields_omitted_when_absent(self):
+        rec = _hist_record(merged_at=None, evidence="", municipality_type="")
+        doc = build_historical_municipality_doc({"0105": rec})
+        node = next(
+            n for n in doc["@graph"]
+            if n["@id"] == "estleg:HistoricalMunicipality_0105"
+        )
+        assert "estleg:mergedAt" not in node
+        assert "estleg:mergerEvidence" not in node
+        assert "estleg:municipalityType" not in node
+        # The always-present fields are still there.
+        assert node["estleg:formerEhakCode"] == "0105"
+        assert node["estleg:succeededBy"] == {"@id": "estleg:Municipality_EHAK_0480"}
+
+    def test_issuer_slugs_not_serialised_onto_nodes(self):
+        # issuerSlugs is coverage metadata only; it must not leak into
+        # the JSON-LD (which would imply an Issuer-range predicate that
+        # does not exist).
+        doc = build_historical_municipality_doc({
+            "0105": _hist_record(issuer_slugs=["a_vallavolikogu", "a_vallavalitsus"])
+        })
+        node = next(
+            n for n in doc["@graph"]
+            if n["@id"] == "estleg:HistoricalMunicipality_0105"
+        )
+        assert "estleg:enactedBy" not in node
+        assert "issuerSlugs" not in node
+
+    def test_nodes_emitted_in_ascending_former_code_order(self):
+        doc = build_historical_municipality_doc({
+            "0480": _hist_record(former_code="0480", former_name="Halliste vald",
+                                 succ_code="0480"),
+            "0105": _hist_record(former_code="0105"),
+        })
+        instance_ids = [
+            n["@id"] for n in doc["@graph"]
+            if n["@id"].startswith("estleg:HistoricalMunicipality_")
+        ]
+        assert instance_ids == [
+            "estleg:HistoricalMunicipality_0105",
+            "estleg:HistoricalMunicipality_0480",
+        ]
+
+    def test_succeededBy_targets_resolve_in_real_municipality_corpus(self):
+        # Every estleg:succeededBy IRI emitted from the real registry
+        # must correspond to a node that actually exists in the
+        # municipality corpus (estleg:Municipality_EHAK_<code>).
+        issuers = json.loads(
+            (REPO_ROOT / "data" / "ehak" / "issuers.json").read_text(
+                encoding="utf-8",
+            )
+        )
+        muns = load_municipalities(EHAK_DIR / "municipalities.json")
+        hist = extract_historical_municipalities(issuers, muns)
+        doc = build_historical_municipality_doc(hist)
+        # Build the set of municipality IRIs the same way enrich_kov
+        # does (estleg:Municipality_EHAK_<code>).
+        municipality_iris = {f"estleg:Municipality_EHAK_{c}" for c in muns}
+        for node in doc["@graph"]:
+            ref = node.get("estleg:succeededBy")
+            if not ref:
+                continue
+            assert ref["@id"] in municipality_iris, (
+                f"{node['@id']} succeededBy {ref['@id']} does not resolve "
+                "to a real municipality node"
+            )
+
+
+class TestControlledVocabularyTerms:
+    @pytest.fixture(scope="class")
+    def vocab_ids(self) -> dict[str, dict]:
+        doc = json.loads(CONTROLLED_VOCAB.read_text(encoding="utf-8"))
+        return {n["@id"]: n for n in doc.get("@graph", []) if "@id" in n}
+
+    def test_class_present(self, vocab_ids):
+        node = vocab_ids.get("estleg:HistoricalMunicipality")
+        assert node is not None, "estleg:HistoricalMunicipality not defined"
+        assert "owl:Class" in node["@type"]
+        # Deliberately NOT a subclass of estleg:Municipality (would pull
+        # in the Municipality SHACL shape's IRI/ehakCode constraints).
+        assert "rdfs:subClassOf" not in node
+        assert node.get("rdfs:label")
+        assert node.get("rdfs:comment")
+
+    def test_datatype_properties_present(self, vocab_ids):
+        for term, rng in (
+            ("estleg:formerEhakCode", "xsd:string"),
+            ("estleg:formerName", "xsd:string"),
+            ("estleg:mergedAt", "xsd:date"),
+            ("estleg:mergerEvidence", "xsd:string"),
+            ("estleg:municipalityType", "xsd:string"),
+        ):
+            node = vocab_ids.get(term)
+            assert node is not None, f"{term} not defined"
+            assert "owl:DatatypeProperty" in node["@type"], term
+            assert node["rdfs:range"] == {"@id": rng}, term
+            assert node.get("rdfs:label") and node.get("rdfs:comment"), term
+
+    def test_object_property_present(self, vocab_ids):
+        node = vocab_ids.get("estleg:succeededBy")
+        assert node is not None, "estleg:succeededBy not defined"
+        assert "owl:ObjectProperty" in node["@type"]
+        assert node["rdfs:range"] == {"@id": "estleg:Municipality"}
+        assert node.get("rdfs:label") and node.get("rdfs:comment")
+
+
+def _validate(graph_json: dict) -> tuple[bool, str]:
+    pyshacl = pytest.importorskip("pyshacl")
+    rdflib = pytest.importorskip("rdflib")
+    g = rdflib.Graph()
+    g.parse(data=json.dumps(graph_json), format="json-ld")
+    shapes = rdflib.Graph().parse(str(SHAPES), format="turtle")
+    conforms, _, msg = pyshacl.validate(g, shacl_graph=shapes, inference="rdfs")
+    return conforms, str(msg)
+
+
+def _well_formed_node(**overrides) -> dict:
+    node = {
+        "@context": CONTEXT,
+        "@id": "estleg:HistoricalMunicipality_0105",
+        "@type": ["owl:NamedIndividual", "estleg:HistoricalMunicipality"],
+        "rdfs:label": "Abja vald",
+        "estleg:formerEhakCode": "0105",
+        "estleg:formerName": "Abja vald",
+        "estleg:succeededBy": {"@id": "estleg:Municipality_EHAK_0480"},
+        "estleg:municipalityType": "vald",
+        "estleg:mergedAt": {"@value": "2017-10-15", "@type": "xsd:date"},
+        "estleg:mergerEvidence": "Wikidata: Abja vald (EHAK 0105) -> Mulgi vald (EHAK 0480)",
+    }
+    node.update(overrides)
+    return node
+
+
+class TestHistoricalMunicipalityShape:
+    def test_well_formed_node_passes(self):
+        ok, msg = _validate(_well_formed_node())
+        assert ok, msg
+
+    def test_minimal_node_passes(self):
+        # Only the required fields (no mergedAt / mergerEvidence /
+        # municipalityType) — must still conform.
+        node = {
+            "@context": CONTEXT,
+            "@id": "estleg:HistoricalMunicipality_0105",
+            "@type": ["owl:NamedIndividual", "estleg:HistoricalMunicipality"],
+            "rdfs:label": "Abja vald",
+            "estleg:formerEhakCode": "0105",
+            "estleg:formerName": "Abja vald",
+            "estleg:succeededBy": {"@id": "estleg:Municipality_EHAK_0480"},
+        }
+        ok, msg = _validate(node)
+        assert ok, msg
+
+    def test_missing_former_ehak_code_fails(self):
+        node = _well_formed_node()
+        del node["estleg:formerEhakCode"]
+        ok, _ = _validate(node)
+        assert not ok
+
+    def test_missing_former_name_fails(self):
+        node = _well_formed_node()
+        del node["estleg:formerName"]
+        ok, _ = _validate(node)
+        assert not ok
+
+    def test_missing_succeeded_by_fails(self):
+        node = _well_formed_node()
+        del node["estleg:succeededBy"]
+        ok, _ = _validate(node)
+        assert not ok
+
+    def test_non_four_digit_former_ehak_code_fails(self):
+        ok, _ = _validate(_well_formed_node(**{"estleg:formerEhakCode": "105"}))
+        assert not ok
+
+    def test_out_of_enum_municipality_type_fails(self):
+        ok, _ = _validate(_well_formed_node(**{"estleg:municipalityType": "alev"}))
+        assert not ok
+
+    def test_succeeded_by_literal_instead_of_iri_fails(self):
+        ok, _ = _validate(_well_formed_node(**{"estleg:succeededBy": "0480"}))
+        assert not ok
+
+    def test_non_pattern_iri_fails(self):
+        ok, _ = _validate(_well_formed_node(**{"@id": "estleg:HistoricalMunicipality_Abja"}))
+        assert not ok
+
+    def test_bad_merged_at_datatype_fails(self):
+        ok, _ = _validate(_well_formed_node(**{
+            "estleg:mergedAt": {"@value": "2017-10-15", "@type": "xsd:string"},
+        }))
+        assert not ok
+
+
+class TestGeneratedFileIntegrity:
+    """The committed ``data/ehak/historical_municipalities.jsonld`` must
+    match what the builder produces from the current registry, and must
+    be internally well-formed."""
+
+    @pytest.fixture(scope="class")
+    def committed_doc(self) -> dict:
+        if not HISTORICAL_OUT.exists():
+            pytest.fail(f"{HISTORICAL_OUT} not found — run enrich_kov_layer1.py")
+        return json.loads(HISTORICAL_OUT.read_text(encoding="utf-8"))
+
+    def test_matches_regenerated_doc(self, committed_doc):
+        issuers = json.loads(
+            (EHAK_DIR / "issuers.json").read_text(encoding="utf-8")
+        )
+        muns = load_municipalities(EHAK_DIR / "municipalities.json")
+        hist = extract_historical_municipalities(issuers, muns)
+        regenerated = build_historical_municipality_doc(hist)
+        assert committed_doc == regenerated, (
+            "data/ehak/historical_municipalities.jsonld is stale — "
+            "re-run scripts/enrich_kov_layer1.py"
+        )
+
+    def test_one_node_per_distinct_former_code(self, committed_doc):
+        instances = [
+            n for n in committed_doc["@graph"]
+            if "estleg:HistoricalMunicipality" in n.get("@type", [])
+        ]
+        codes = [n["estleg:formerEhakCode"] for n in instances]
+        assert len(codes) == len(set(codes)), "duplicate former EHAK codes"
+        assert len(instances) >= 130
+
+    def test_ids_unique_and_match_former_code(self, committed_doc):
+        ids = [n["@id"] for n in committed_doc["@graph"]]
+        assert len(ids) == len(set(ids))
+        for n in committed_doc["@graph"]:
+            if "estleg:HistoricalMunicipality" in n.get("@type", []):
+                assert n["@id"] == f"estleg:HistoricalMunicipality_{n['estleg:formerEhakCode']}"
+
+    def test_no_self_succession(self, committed_doc):
+        for n in committed_doc["@graph"]:
+            if "estleg:HistoricalMunicipality" not in n.get("@type", []):
+                continue
+            succ = n["estleg:succeededBy"]["@id"]
+            assert succ != f"estleg:Municipality_EHAK_{n['estleg:formerEhakCode']}"
+
+    def test_uses_canonical_estleg_namespace(self, committed_doc):
+        assert committed_doc["@context"]["estleg"] == "https://data.riik.ee/ontology/estleg#"

--- a/tests/test_kov_registry.py
+++ b/tests/test_kov_registry.py
@@ -10,9 +10,11 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 import pytest
 
 from kov_registry import (
+    HALDUSREFORM_2017_MERGE_DATE,
     auto_match_municipality,
     build_issuer_registry,
     discover_issuer_slugs,
+    extract_historical_municipalities,
     load_curated_map,
     load_municipalities,
     normalize_title,
@@ -497,6 +499,208 @@ class TestNormalizeTitle:
             parse_issuer_slug("tallinna_linnavolikogu"),
         )
         assert out == "alevi haldusakt"
+
+
+def _issuer_row(
+    slug: str,
+    current: str,
+    *,
+    source: str = "haldusreform-2017",
+    evidence: str = "",
+    historical_name: str = "",
+) -> dict:
+    return {
+        "slug": slug,
+        "displayName": slug.replace("_", " ").title(),
+        "bodyType": "volikogu" if slug.endswith("volikogu") else "valitsus",
+        "currentMunicipalityCode": current,
+        "mappingSource": source,
+        "mappingEvidence": evidence,
+        "historicalMunicipalityName": historical_name,
+    }
+
+
+class TestExtractHistoricalMunicipalities:
+    """`extract_historical_municipalities` derives one
+    estleg:HistoricalMunicipality per distinct pre-merger EHAK code from
+    the issuer registry's mappingEvidence citations — issue #130."""
+
+    def test_parses_haldusreform_arrow_evidence(self):
+        rows = [
+            _issuer_row(
+                "abja_vallavolikogu", "0480",
+                evidence=(
+                    "Wikidata: Abja vald (EHAK 0105) -> Mulgi vald "
+                    "(EHAK 0480); per RT I 21.06.2017 1"
+                ),
+                historical_name="Abja",
+            ),
+        ]
+        hist = extract_historical_municipalities(rows)
+        assert set(hist) == {"0105"}
+        abja = hist["0105"]
+        assert abja["formerEhakCode"] == "0105"
+        assert abja["formerName"] == "Abja vald"
+        assert abja["municipalityType"] == "vald"
+        assert abja["succeededByCode"] == "0480"
+        assert abja["mergedAt"] == HALDUSREFORM_2017_MERGE_DATE == "2017-10-15"
+        assert "EHAK 0105" in abja["mergerEvidence"]
+        assert abja["issuerSlugs"] == ["abja_vallavolikogu"]
+
+    def test_parses_linn_unit_type(self):
+        rows = [
+            _issuer_row(
+                "elva_linnavolikogu", "0171",
+                evidence=(
+                    "Wikidata: Elva linn (EHAK 0170) -> Elva vald "
+                    "(EHAK 0171); per RT I 21.06.2017 1"
+                ),
+            ),
+        ]
+        hist = extract_historical_municipalities(rows)
+        assert hist["0170"]["municipalityType"] == "linn"
+        assert hist["0170"]["formerName"] == "Elva linn"
+
+    def test_parses_compound_hyphenated_name(self):
+        rows = [
+            _issuer_row(
+                "kohtla_nomme_vallavolikogu", "0803",
+                evidence=(
+                    "Wikidata: Kohtla-Nõmme vald (EHAK 0323) -> Toila "
+                    "vald (EHAK 0803); per RT I 21.06.2017 1"
+                ),
+            ),
+        ]
+        hist = extract_historical_municipalities(rows)
+        assert hist["0323"]["formerName"] == "Kohtla-Nõmme vald"
+
+    def test_parses_manual_review_split_prose(self):
+        # The manual-review rows use prose evidence that still opens
+        # with "<Old> vald (EHAK <old>)" — the predecessor.
+        rows = [
+            _issuer_row(
+                "misso_vallavolikogu", "0698",
+                source="manual-review",
+                evidence=(
+                    "Misso vald (EHAK 0468) was split in the 2017 "
+                    "reform: most territory plus the administrative "
+                    "center merged into Rõuge vald (0698); southern "
+                    "parishes joined Setomaa vald (0732)."
+                ),
+            ),
+        ]
+        hist = extract_historical_municipalities(rows)
+        assert set(hist) == {"0468"}
+        assert hist["0468"]["succeededByCode"] == "0698"
+        assert hist["0468"]["mergedAt"] == "2017-10-15"
+
+    def test_dedups_multiple_issuers_for_one_unit(self):
+        ev = (
+            "Wikidata: Alatskivi vald (EHAK 0126) -> Peipsiääre vald "
+            "(EHAK 0586); per RT I 21.06.2017 1"
+        )
+        rows = [
+            _issuer_row("alatskivi_vallavalitsus", "0586", evidence=ev),
+            _issuer_row("alatskivi_vallavolikogu", "0586", evidence=ev),
+        ]
+        hist = extract_historical_municipalities(rows)
+        assert set(hist) == {"0126"}
+        # Both issuers collected, sorted.
+        assert hist["0126"]["issuerSlugs"] == [
+            "alatskivi_vallavalitsus", "alatskivi_vallavolikogu",
+        ]
+
+    def test_auto_match_issuers_contribute_no_historical_node(self):
+        # auto-match issuers map to a still-current municipality and
+        # have empty mappingEvidence — no historical node.
+        rows = [
+            _issuer_row(
+                "tallinna_linnavolikogu", "0784", source="auto-match",
+                evidence="",
+            ),
+        ]
+        assert extract_historical_municipalities(rows) == {}
+
+    def test_unparseable_evidence_is_skipped(self):
+        rows = [
+            _issuer_row(
+                "weird_vallavolikogu", "0480",
+                evidence="some note without a parseable predecessor EHAK ref",
+            ),
+        ]
+        assert extract_historical_municipalities(rows) == {}
+
+    def test_conflicting_successors_raise(self):
+        # Same historical code reached via two issuers but with
+        # different successors → data bug, surface it.
+        rows = [
+            _issuer_row(
+                "x_vallavalitsus", "0480",
+                evidence="Foo vald (EHAK 0105) -> Bar vald (EHAK 0480)",
+            ),
+            _issuer_row(
+                "x_vallavolikogu", "0481",
+                evidence="Foo vald (EHAK 0105) -> Baz vald (EHAK 0481)",
+            ),
+        ]
+        with pytest.raises(ValueError, match="conflicting successors"):
+            extract_historical_municipalities(rows)
+
+    def test_successor_not_in_municipalities_raises_when_checked(self):
+        rows = [
+            _issuer_row(
+                "x_vallavolikogu", "9999",
+                evidence="Foo vald (EHAK 0105) -> Ghost vald (EHAK 9999)",
+            ),
+        ]
+        muns = load_municipalities(MIN_MUNICIPALITIES)
+        with pytest.raises(ValueError, match="9999"):
+            extract_historical_municipalities(rows, muns)
+        # Without the municipalities arg the check is skipped.
+        assert "0105" in extract_historical_municipalities(rows)
+
+    def test_self_succession_evidence_is_skipped(self):
+        # If the first (EHAK NNNN) match equals the current code, it is
+        # not a predecessor — don't emit a self-succession edge.
+        rows = [
+            _issuer_row(
+                "x_vallavolikogu", "0480",
+                evidence="Mulgi vald (EHAK 0480) absorbed several units",
+            ),
+        ]
+        assert extract_historical_municipalities(rows) == {}
+
+    def test_real_registry_yields_expected_shape(self):
+        # Drive the live data/ehak/issuers.json: every issuer that is
+        # NOT mappingSource=auto-match must contribute to exactly one
+        # historical node, and every node must have a 4-digit code, a
+        # non-empty name ending in " vald" or " linn", and a successor
+        # that exists in the current municipalities registry.
+        issuers = json.loads(
+            (REPO_ROOT / "data" / "ehak" / "issuers.json").read_text(
+                encoding="utf-8",
+            )
+        )
+        muns = load_municipalities(
+            REPO_ROOT / "data" / "ehak" / "municipalities.json"
+        )
+        hist = extract_historical_municipalities(issuers, muns)
+        non_auto = [r for r in issuers if r["mappingSource"] != "auto-match"]
+        assert len(hist) >= 130, (
+            f"expected ~150 historical municipalities, got {len(hist)}"
+        )
+        # Every non-auto issuer is accounted for in some node's slug list.
+        accounted = {s for h in hist.values() for s in h["issuerSlugs"]}
+        assert {r["slug"] for r in non_auto} == accounted
+        for code, h in hist.items():
+            assert len(code) == 4 and code.isdigit()
+            assert h["formerName"].endswith((" vald", " linn"))
+            assert h["municipalityType"] in {"vald", "linn"}
+            assert h["succeededByCode"] in muns
+            assert h["succeededByCode"] != code
+            # All real entries are 2017-haldusreform (or manual-review
+            # 2017 splits), so every node carries the merger date.
+            assert h["mergedAt"] == "2017-10-15"
 
 
 class TestMetadataJsonLd:


### PR DESCRIPTION
## Summary
Pre-merger Estonian municipalities (mostly the 2017 haldusreform) are now distinct `estleg:HistoricalMunicipality` entities with merger metadata + successor relations, parsed from `data/ehak/issuers.json`'s `mappingEvidence`.

- New vocab: `estleg:HistoricalMunicipality` (owl:Class) + `formerEhakCode`/`formerName`/`mergedAt`/`mergerEvidence`/`municipalityType`/`succeededBy`; also materialised `estleg:Municipality` as a reusable class so `succeededBy`'s range resolves in a validated file.
- SHACL `HistoricalMunicipalityShape` (IRI pattern `…#HistoricalMunicipality_[0-9]{4}`, the property constraints).
- Build path: extended `kov_registry.py` + `enrich_kov_layer1.py` (step 2b) → `data/ehak/historical_municipalities.jsonld` (150 instances; placed under `data/ehak/` not `krr_outputs/` to avoid the `metadata.jsonld` file-count gate; added to the `kov` SHACL bucket).
- 150 nodes emitted (132 vald / 18 linn), all `succeededBy → estleg:Municipality_EHAK_<code>` resolve (no gaps). `combined_ontology.jsonld` regenerated. +36 tests.

## Test plan
- [x] `pytest tests/` — 1,301 passed, 2 skipped
- [x] `ruff check scripts/ tests/` — clean
- [x] `python3 scripts/validate_all.py` — 0 errors / 1 benign warning; Internal Reference Integrity OK
- [x] `python3 scripts/validate_seadusloome_sync.py` — SHACL PASS
- [x] `python3 scripts/shacl_validate_all.py --bucket kov / --bucket sidecars / --all` — SHACL PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)