### PR TITLE
#132: model lõige (subsection) structure as estleg:Subsection nodes

### DIFF
--- a/krr_outputs/controlled_vocabulary.jsonld
+++ b/krr_outputs/controlled_vocabulary.jsonld
@@ -2075,6 +2075,53 @@
       }
     },
     {
+      "@id": "estleg:Subsection",
+      "@type": [
+        "owl:Class"
+      ],
+      "rdfs:label": "Subsection (lõige)",
+      "rdfs:comment": "A numbered subsection (lõige) of an estleg:LegalProvision — the level Estonian legal citations actually reference (\"TsÜS § 14 lg 2\"). One node per lõige of a paragrahv that has lõige structure; it carries the lõige number (estleg:subsectionNumber), the lõige's own text (estleg:legalText, including the inline (N) punkt markers, mirroring the provision-level legalText), and an estleg:parentProvision link back to the § node. The parent provision keeps its full concatenated estleg:legalText for backward compatibility — the subsections sum to it. Defined for issue #132 (lõige level); modelling the punkt/alapunkt level below lõige is deferred to a follow-up."
+    },
+    {
+      "@id": "estleg:subsectionNumber",
+      "@type": [
+        "owl:DatatypeProperty"
+      ],
+      "rdfs:label": "Subsection Number",
+      "rdfs:comment": "The lõige number of an estleg:Subsection as a display string, e.g. \"2\" or \"2¹\" (the kuvatavNr form, falling back to loigeNr). Kept as a string because superscripted lõige numbers (lg 2¹) are not integers.",
+      "rdfs:range": {
+        "@id": "xsd:string"
+      }
+    },
+    {
+      "@id": "estleg:hasSubsection",
+      "@type": [
+        "owl:ObjectProperty"
+      ],
+      "rdfs:label": "Has Subsection",
+      "rdfs:comment": "Links an estleg:LegalProvision to one of its estleg:Subsection (lõige) nodes. A provision with lõige structure carries one estleg:hasSubsection triple per lõige, in document order; a provision with no lõiked carries none (its text lives directly on the § node). Inverse of estleg:parentProvision.",
+      "rdfs:range": {
+        "@id": "estleg:Subsection"
+      },
+      "owl:inverseOf": {
+        "@id": "estleg:parentProvision"
+      }
+    },
+    {
+      "@id": "estleg:parentProvision",
+      "@type": [
+        "owl:ObjectProperty"
+      ],
+      "rdfs:label": "Parent Provision",
+      "rdfs:comment": "Links an estleg:Subsection (lõige) to the estleg:LegalProvision (§) it belongs to. Exactly one per Subsection. Inverse of estleg:hasSubsection.",
+      "rdfs:range": {
+        "@id": "estleg:LegalProvision"
+      },
+      "owl:inverseOf": {
+        "@id": "estleg:hasSubsection"
+      }
+    },
+    {
       "@id": "estleg:Annotation",
       "@type": [
         "owl:Class"

--- a/scripts/generate_all_laws.py
+++ b/scripts/generate_all_laws.py
@@ -203,6 +203,106 @@ def _walk_paragraphs_direct(
     return out
 
 
+def _loige_body_text(loige_el: ET.Element) -> str:
+    """Return the joined text of one ``loige`` subtree.
+
+    Concatenates the ``lauseOsa``/``lause``/``tavatekst`` fragments below
+    the lõige, normalising whitespace and dropping fragments of length
+    <= 3 (the same filter ``collect_full_text`` applies). The lõige's own
+    ``(N)`` marker is *not* prepended here — callers add it when they want
+    the marker (the provision-level ``estleg:legalText`` does;
+    ``estleg:legalText`` on a Subsection node also does, mirroring the
+    provision-level form).
+    """
+    body_parts: list[str] = []
+    for grandchild in loige_el.iter():
+        tag = ln(grandchild.tag)
+        if tag in ("lauseOsa", "lause", "tavatekst"):
+            txt = "".join(grandchild.itertext()).strip()
+            txt = re.sub(r"\s+", " ", txt)
+            if txt and len(txt) > 3:
+                body_parts.append(txt)
+    return " ".join(body_parts).strip()
+
+
+def _superscript_from_text(value: str) -> str:
+    """Extract a trailing superscript index from a number-bearing string.
+
+    Mirrors the ``kuvatavNr`` branch of ``_superscript_index`` but works
+    on a bare string (a ``loige`` ``kuvatavNr`` like ``(2)`` or ``(2¹)``).
+    Machine ``loigeNr`` superscripts are carried in the ``ylaIndeks``
+    attribute, so this fallback only matters for the display form.
+    Returns the index as a plain digit string ("1", "2", ...) or ``""``.
+    """
+    if not value:
+        return ""
+    m = re.search(
+        r"\d+\s*(?:<sup>\s*(\d+)\s*</sup>|([¹²³⁰⁴-⁹]+))",
+        value,
+    )
+    if not m:
+        return ""
+    if m.group(1):
+        return m.group(1).strip()
+    if m.group(2):
+        return "".join(_SUPERSCRIPT_DIGIT_MAP.get(ch, "") for ch in m.group(2))
+    return ""
+
+
+def _loige_numbers(loige_el: ET.Element) -> tuple[str, str]:
+    """Return ``(display_number, id_suffix)`` for one ``loige`` element.
+
+    The *display number* is the human-facing lõige label — preferring the
+    ``kuvatavNr`` CDATA (stripped of its parentheses; e.g. ``(2¹)`` →
+    ``2¹``) and falling back to ``loigeNr``. The *id suffix* is the
+    canonical, order-independent IRI fragment: the base ``loigeNr`` digits
+    plus any superscript index (``ylaIndeks`` on the ``loigeNr`` element,
+    or a Unicode/``<sup>`` superscript glyph in ``kuvatavNr``), joined
+    with an underscore — ``§ 14 lg 2¹`` → ``2_1``. This mirrors
+    ``_paragraph_id_suffix`` for paragrahv elements.
+    """
+    loige_nr = ""
+    ya = ""
+    for sub in loige_el:
+        if ln(sub.tag) == "loigeNr":
+            if sub.text:
+                loige_nr = sub.text.strip()
+            ya = (sub.attrib.get("ylaIndeks") or "").strip()
+            break
+
+    kuv_raw = ""
+    for sub in loige_el:
+        if ln(sub.tag) == "kuvatavNr":
+            kuv_raw = "".join(sub.itertext()).strip()
+            break
+    kuv_inner = re.sub(r"[()]", "", kuv_raw).strip() if kuv_raw else ""
+
+    # Display: kuvatavNr (without parens) wins, else loigeNr, else "".
+    display = kuv_inner or loige_nr
+
+    # ID suffix base + superscript.
+    base = loige_nr
+    if not base:
+        # No machine loigeNr — fall back to the digits in the display form.
+        m = re.match(r"\s*(\d+)", kuv_inner)
+        base = m.group(1) if m else kuv_inner
+    sup = ya
+    if not sup and kuv_raw:
+        sup = _superscript_from_text(kuv_raw)
+    # sanitize_id keeps [0-9A-Za-z_] only, so a base like "2" stays "2"
+    # and any stray punctuation is dropped before it becomes an IRI fragment.
+    base_clean = sanitize_id(base) if base else "Unknown"
+    if sup:
+        return display, f"{base_clean}_{sanitize_id(sup)}"
+    return display, base_clean
+
+
+def _iter_loiked(el: ET.Element) -> list[ET.Element]:
+    """Return the direct ``loige`` children of a paragrahv element, in
+    document order."""
+    return [child for child in el if ln(child.tag) == "loige"]
+
+
 def collect_full_text(el: ET.Element) -> str:
     """Return the complete text of a provision, preserving lõige boundaries.
 
@@ -213,32 +313,9 @@ def collect_full_text(el: ET.Element) -> str:
     single-paragraph laws still emit useful text.
     """
     lõige_blocks: list[str] = []
-    for child in el:
-        if ln(child.tag) != "loige":
-            continue
-        loige_nr = ""
-        for sub in child:
-            if ln(sub.tag) == "loigeNr" and sub.text:
-                loige_nr = sub.text.strip()
-                break
-        if not loige_nr:
-            for sub in child:
-                if ln(sub.tag) == "kuvatavNr":
-                    raw = "".join(sub.itertext()).strip()
-                    inner = re.sub(r"[()]", "", raw).strip()
-                    if inner:
-                        loige_nr = inner
-                        break
-
-        body_parts: list[str] = []
-        for grandchild in child.iter():
-            tag = ln(grandchild.tag)
-            if tag in ("lauseOsa", "lause", "tavatekst"):
-                txt = "".join(grandchild.itertext()).strip()
-                txt = re.sub(r"\s+", " ", txt)
-                if txt and len(txt) > 3:
-                    body_parts.append(txt)
-        body = " ".join(body_parts).strip()
+    for child in _iter_loiked(el):
+        loige_nr, _suffix = _loige_numbers(child)
+        body = _loige_body_text(child)
         if not body:
             continue
         if loige_nr:
@@ -258,6 +335,84 @@ def collect_full_text(el: ET.Element) -> str:
             if txt and len(txt) > 3:
                 parts.append(txt)
     return " ".join(parts)
+
+
+def build_subsections(
+    par_el: ET.Element,
+    provision_id: str,
+    *,
+    abbrev_prefix: str,
+    par_suffix: str,
+    paragraph_display: str,
+    osa_nr: str | None = None,
+    seen_ids: set[str] | None = None,
+) -> list[dict]:
+    """Build ``estleg:Subsection`` nodes for one paragrahv's ``loige`` children.
+
+    Each lõige becomes one ``estleg:Subsection`` named individual:
+      * ``@id``: ``estleg:<PREFIX>[_Osa<N>]_Par_<parSuffix>_Lg_<loigeSuffix>``
+        (superscript ``§ 14 lg 2¹`` → ``..._Par_14_Lg_2_1``);
+      * ``@type``: ``["estleg:Subsection", "owl:NamedIndividual"]``;
+      * ``estleg:subsectionNumber``: the display lõige number as a string;
+      * ``estleg:legalText``: the lõige's own text, prefixed with its
+        ``(N)`` marker (mirroring the provision-level ``estleg:legalText``);
+      * ``estleg:parentProvision``: ``{"@id": provision_id}``;
+      * ``rdfs:label``: e.g. ``"§ 14 lg 2"``.
+
+    Subsections whose lõige carries no usable text are skipped (an empty
+    lõige is a structural artefact, not a citable unit, and SHACL requires
+    ``estleg:legalText``). Returns the nodes in document order. ``seen_ids``,
+    when supplied, accumulates the emitted Subsection IRIs and is checked
+    for collisions (a duplicate raises ``ValueError`` — the same fail-fast
+    contract the paragraph IRIs use).
+    """
+    if seen_ids is None:
+        seen_ids = set()
+    # Paragraph display strings from kuvatavNr carry a trailing period and
+    # whitespace ("§ 14. "); strip it so the Subsection label reads
+    # "§ 14 lg 2" rather than "§ 14.  lg 2".
+    par_label_base = None
+    if paragraph_display:
+        cleaned = re.sub(r"\s+", " ", paragraph_display).strip().rstrip(".").strip()
+        par_label_base = cleaned or None
+    subsection_nodes: list[dict] = []
+    for loige_el in _iter_loiked(par_el):
+        display_nr, suffix = _loige_numbers(loige_el)
+        body = _loige_body_text(loige_el)
+        if not body:
+            # Empty lõige (e.g. a repealed-marker placeholder) — no
+            # citable text, so no Subsection node.
+            continue
+        osa_segment = f"_Osa{osa_nr}" if osa_nr else ""
+        sub_id = f"estleg:{abbrev_prefix}{osa_segment}_Par_{par_suffix}_Lg_{suffix}"
+        if sub_id in seen_ids:
+            raise ValueError(
+                f"Duplicate subsection IRI {sub_id!r} produced for prefix "
+                f"{abbrev_prefix!r}; check loigeNr / ylaIndeks / kuvatavNr "
+                f"in the source XML."
+            )
+        seen_ids.add(sub_id)
+
+        legal_text = f"({display_nr}) {body}" if display_nr else body
+
+        # estleg:legalText / estleg:subsectionNumber are emitted as plain
+        # (xsd:string) literals, matching estleg:SubsectionShape's
+        # sh:datatype xsd:string and the existing estleg:legalText data in
+        # the corpus (the generate_missing_parts.py outputs).
+        node: dict = {
+            "@id": sub_id,
+            "@type": ["estleg:Subsection", "owl:NamedIndividual"],
+            "estleg:subsectionNumber": display_nr or suffix,
+            "estleg:legalText": legal_text,
+            "estleg:parentProvision": {"@id": provision_id},
+        }
+        if par_label_base and display_nr:
+            node["rdfs:label"] = {
+                "@value": f"{par_label_base} lg {display_nr}",
+                "@language": "et",
+            }
+        subsection_nodes.append(node)
+    return subsection_nodes
 
 
 class SourceListFetchError(RuntimeError):
@@ -834,6 +989,9 @@ def generate_law_jsonld(
 
     # Add paragraph nodes
     seen_ids: set[str] = set()
+    # Issue #132: every estleg:Subsection IRI emitted in this file —
+    # a collision (loigeNr/ylaIndeks/kuvatavNr clash) fails fast.
+    seen_subsection_ids: set[str] = set()
     for p in paragrahvid:
         p_nr = ct(p, "paragrahvNr") or "?"
         p_title = ct(p, "paragrahvPealkiri") or ""
@@ -845,7 +1003,8 @@ def generate_law_jsonld(
         # plus any superscript index (ylaIndeks="N" or §X¹). This is
         # order-independent so partial regenerations no longer drift
         # IRIs based on insertion order.
-        p_id = f"estleg:{prefix}_Par_{_paragraph_id_suffix(p)}"
+        par_suffix = _paragraph_id_suffix(p)
+        p_id = f"estleg:{prefix}_Par_{par_suffix}"
 
         if p_id in seen_ids:
             raise ValueError(
@@ -900,7 +1059,26 @@ def generate_law_jsonld(
         if container_ref:
             node["estleg:isPartOf"] = {"@id": container_ref}
 
+        # Issue #132: emit estleg:Subsection nodes for each lõige. The
+        # provision keeps its full concatenated estleg:legalText (the sum
+        # of the subsections) for backward compatibility; the per-lõige
+        # text additionally lives on Subsection nodes — the level
+        # citations actually reference ("TsÜS § 14 lg 2").
+        subsection_nodes = build_subsections(
+            p,
+            p_id,
+            abbrev_prefix=prefix,
+            par_suffix=par_suffix,
+            paragraph_display=p_display,
+            seen_ids=seen_subsection_ids,
+        )
+        if subsection_nodes:
+            node["estleg:hasSubsection"] = [
+                {"@id": s["@id"]} for s in subsection_nodes
+            ]
+
         graph.append(node)
+        graph.extend(subsection_nodes)
 
     return {"@context": CONTEXT, "@graph": graph}
 
@@ -1189,6 +1367,8 @@ def generate_multipart_law(
             graph.insert(2, scheme_node)
 
         seen_ids: set[str] = set()
+        # Issue #132: Subsection IRIs emitted within this osa file.
+        seen_subsection_ids: set[str] = set()
         for p in paragrahvid:
             p_nr = ct(p, "paragrahvNr") or "?"
             p_title = ct(p, "paragrahvPealkiri") or ""
@@ -1196,7 +1376,8 @@ def generate_multipart_law(
             text = collect_text(p)
             full_text = collect_full_text(p)
             # Issue #156/#165 fix 2: superscript-aware paragraph IRI suffix.
-            p_id = f"estleg:{prefix}_Osa{osa_nr}_Par_{_paragraph_id_suffix(p)}"
+            par_suffix = _paragraph_id_suffix(p)
+            p_id = f"estleg:{prefix}_Osa{osa_nr}_Par_{par_suffix}"
             if p_id in seen_ids:
                 raise ValueError(
                     f"Duplicate paragraph IRI {p_id!r} produced for prefix "
@@ -1245,7 +1426,22 @@ def generate_multipart_law(
             container_ref = par_to_container.get(p_num)
             if container_ref:
                 node["estleg:isPartOf"] = {"@id": container_ref}
+            # Issue #132: per-lõige estleg:Subsection nodes (osa-scoped IRIs).
+            subsection_nodes = build_subsections(
+                p,
+                p_id,
+                abbrev_prefix=prefix,
+                par_suffix=par_suffix,
+                paragraph_display=p_display,
+                osa_nr=str(osa_nr),
+                seen_ids=seen_subsection_ids,
+            )
+            if subsection_nodes:
+                node["estleg:hasSubsection"] = [
+                    {"@id": s["@id"]} for s in subsection_nodes
+                ]
             graph.append(node)
+            graph.extend(subsection_nodes)
 
         filename = f"{slug}_osa{osa_nr}_peep.json"
         results.append((filename, {"@context": CONTEXT, "@graph": graph}))

--- a/shacl/estonian_legal_shapes.ttl
+++ b/shacl/estonian_legal_shapes.ttl
@@ -247,6 +247,63 @@ estleg:LegalProvisionShape
         sh:nodeKind sh:IRI ;
         sh:name "currentVersion" ;
         sh:description "Optional — the latest estleg:ProvisionVersion in this provision's text history. Population is future work (#131 follow-up)." ;
+    ] ;
+    # --- subsection (lõige) model (issue #132) ---
+    # Optional: a provision with no lõiked carries no estleg:hasSubsection
+    # and still conforms; a provision with lõige structure links one
+    # estleg:Subsection per lõige (in document order). Each Subsection
+    # node is validated by estleg:SubsectionShape below.
+    sh:property [
+        sh:path estleg:hasSubsection ;
+        sh:minCount 0 ;
+        sh:nodeKind sh:IRI ;
+        sh:name "hasSubsection" ;
+        sh:description "Optional — estleg:Subsection (lõige) nodes belonging to this provision, one per lõige in document order. Absent on provisions with no lõige structure (their text lives directly on the § node)." ;
+    ] .
+
+# Shape for Subsection (lõige) instances — issue #132.
+#
+# An estleg:Subsection is one numbered lõige of an estleg:LegalProvision —
+# the level Estonian citations actually reference ("TsÜS § 14 lg 2").
+# IRI form: estleg:<PREFIX>[_Osa<N>]_Par_<parSuffix>_Lg_<loigeSuffix>
+# (superscript "§ 14 lg 2¹" → ..._Par_14_Lg_2_1). Each node carries the
+# lõige number, the lõige's own text (with its (N) marker), and exactly
+# one estleg:parentProvision link back to the § node. estleg:parentProvision
+# is constrained to be an IRI (not sh:class estleg:LegalProvision),
+# mirroring the project-wide convention of dodging subclass-inference
+# requirements (see LegalProvisionShape's targetSubjectsOf comment).
+estleg:SubsectionShape
+    a sh:NodeShape ;
+    sh:targetClass estleg:Subsection ;
+    sh:property [
+        sh:path estleg:subsectionNumber ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:datatype xsd:string ;
+        sh:name "subsectionNumber" ;
+        sh:description "The lõige number as a display string (e.g. \"2\", \"2¹\")." ;
+    ] ;
+    sh:property [
+        sh:path estleg:legalText ;
+        sh:minCount 1 ;
+        sh:datatype xsd:string ;
+        sh:name "legalText" ;
+        sh:description "The lõige's own text (the lõige-and-below text, including its (N) punkt markers), mirroring the provision-level estleg:legalText." ;
+    ] ;
+    sh:property [
+        sh:path estleg:parentProvision ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:IRI ;
+        sh:name "parentProvision" ;
+        sh:description "Exactly one estleg:LegalProvision (the § node, an IRI) this lõige belongs to." ;
+    ] ;
+    sh:property [
+        sh:path rdfs:label ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+        sh:name "label" ;
+        sh:description "Optional human label, e.g. \"§ 14 lg 2\"." ;
     ] .
 
 # Shape for TopicCluster instances.

--- a/tests/test_generate_all_laws.py
+++ b/tests/test_generate_all_laws.py
@@ -1,6 +1,6 @@
 """Regression tests for scripts/generate_all_laws.py.
 
-Covers issues #156, #165, #166. Each test class has a comment that
+Covers issues #156, #165, #166, #132. Each test class has a comment that
 explains which fix it locks down.
 """
 
@@ -13,6 +13,27 @@ import xml.etree.ElementTree as ET
 import pytest
 
 import generate_all_laws
+
+_SHAPES_PATH = (
+    generate_all_laws.REPO_ROOT / "shacl" / "estonian_legal_shapes.ttl"
+)
+
+
+def _shacl_conforms(graph_json: dict) -> tuple[bool, str]:
+    """Validate a hand-built JSON-LD ``@graph`` against the shapes file.
+
+    Skips the test (``importorskip``) when pyshacl/rdflib are not
+    installed in the environment.
+    """
+    pyshacl = pytest.importorskip("pyshacl")
+    rdflib = pytest.importorskip("rdflib")
+    data_graph = rdflib.Graph()
+    data_graph.parse(data=json.dumps(graph_json), format="json-ld")
+    shapes_graph = rdflib.Graph().parse(str(_SHAPES_PATH), format="turtle")
+    conforms, _, msg = pyshacl.validate(
+        data_graph, shacl_graph=shapes_graph, inference="rdfs"
+    )
+    return conforms, str(msg)
 
 
 # ---------------------------------------------------------------------------
@@ -1317,3 +1338,442 @@ class TestActStatusInManifest:
         assert stub_peep["@graph"][0]["estleg:kehtiv"] == {
             "@value": generate_all_laws.DEFAULT_KEHTIV, "@type": "xsd:date"
         }
+
+
+# ---------------------------------------------------------------------------
+# Issue #132 — estleg:Subsection (lõige) nodes
+# ---------------------------------------------------------------------------
+
+
+def _subsection_nodes(graph: list[dict]) -> list[dict]:
+    return [
+        n
+        for n in graph
+        if isinstance(n, dict)
+        and isinstance(n.get("@type"), list)
+        and "estleg:Subsection" in n["@type"]
+    ]
+
+
+class TestSubsectionEmission:
+    """#132: a paragrahv with lõige children emits one estleg:Subsection
+    node per lõige; the § node carries estleg:hasSubsection listing them
+    in document order; a paragrahv with no lõiked emits neither."""
+
+    def _three_loige_law(self) -> dict:
+        xml = """
+        <akt><sisu><peatykk>
+          <peatykkNr>1</peatykkNr><peatykkPealkiri>Peatykk</peatykkPealkiri>
+          <paragrahv>
+            <paragrahvNr>14</paragrahvNr>
+            <kuvatavNr>§ 14. </kuvatavNr>
+            <paragrahvPealkiri>Teovõime</paragrahvPealkiri>
+            <loige><loigeNr>1</loigeNr><kuvatavNr>(1)</kuvatavNr>
+              <tavatekst>Esimene loige tekst siin.</tavatekst></loige>
+            <loige><loigeNr>2</loigeNr><kuvatavNr>(2)</kuvatavNr>
+              <tavatekst>Teine loige paneb piiri.</tavatekst></loige>
+            <loige><loigeNr>3</loigeNr><kuvatavNr>(3)</kuvatavNr>
+              <tavatekst>Kolmas loige tekst.</tavatekst></loige>
+          </paragrahv>
+          <paragrahv>
+            <paragrahvNr>15</paragrahvNr>
+            <kuvatavNr>§ 15. </kuvatavNr>
+            <paragrahvPealkiri>Üks lause</paragrahvPealkiri>
+            <tavatekst>Lihtsalt tekst ilma loigeteta siin.</tavatekst>
+          </paragrahv>
+        </peatykk></sisu></akt>
+        """
+        root = ET.fromstring(xml)
+        alloc = generate_all_laws.PrefixAllocator(registry={})
+        return generate_all_laws.generate_law_jsonld(
+            "Test seadus", "test_seadus", root, abbreviation="TSTS",
+            kehtiv="2026-05-01", allocator=alloc,
+        )
+
+    def test_three_loige_emits_three_subsection_nodes(self):
+        doc = self._three_loige_law()
+        subs = _subsection_nodes(doc["@graph"])
+        sub_ids = [s["@id"] for s in subs]
+        assert sub_ids == [
+            "estleg:TSTS_Par_14_Lg_1",
+            "estleg:TSTS_Par_14_Lg_2",
+            "estleg:TSTS_Par_14_Lg_3",
+        ]
+        for s, n in zip(subs, ("1", "2", "3")):
+            assert s["@type"] == ["estleg:Subsection", "owl:NamedIndividual"]
+            assert s["estleg:subsectionNumber"] == n
+            # legalText is a plain (xsd:string) literal carrying the (N) marker.
+            assert isinstance(s["estleg:legalText"], str)
+            assert s["estleg:legalText"].startswith(f"({n}) ")
+            assert s["estleg:parentProvision"] == {"@id": "estleg:TSTS_Par_14"}
+            assert s["rdfs:label"]["@value"] == f"§ 14 lg {n}"
+
+    def test_provision_has_subsection_list_in_order(self):
+        doc = self._three_loige_law()
+        par14 = next(
+            n for n in doc["@graph"] if n.get("@id") == "estleg:TSTS_Par_14"
+        )
+        assert par14["estleg:hasSubsection"] == [
+            {"@id": "estleg:TSTS_Par_14_Lg_1"},
+            {"@id": "estleg:TSTS_Par_14_Lg_2"},
+            {"@id": "estleg:TSTS_Par_14_Lg_3"},
+        ]
+        # The provision keeps its full concatenated legalText (the sum of
+        # the subsections) for backward compatibility.
+        full = par14["estleg:legalText"]["@value"]
+        assert "(1)" in full and "(2)" in full and "(3)" in full
+
+    def test_paragraph_without_loige_has_no_subsections(self):
+        doc = self._three_loige_law()
+        par15 = next(
+            n for n in doc["@graph"] if n.get("@id") == "estleg:TSTS_Par_15"
+        )
+        assert "estleg:hasSubsection" not in par15
+        # No Subsection node points at § 15.
+        for s in _subsection_nodes(doc["@graph"]):
+            assert s["estleg:parentProvision"]["@id"] != "estleg:TSTS_Par_15"
+
+    def test_superscript_loige_id_and_number(self):
+        """§ 14 lg 2¹ → Subsection @id ..._Par_14_Lg_2_1, subsectionNumber
+        is the display form "2¹"."""
+        xml = """
+        <akt><sisu><peatykk>
+          <peatykkNr>1</peatykkNr><peatykkPealkiri>P</peatykkPealkiri>
+          <paragrahv>
+            <paragrahvNr>14</paragrahvNr><kuvatavNr>§ 14. </kuvatavNr>
+            <paragrahvPealkiri>T</paragrahvPealkiri>
+            <loige><loigeNr>2</loigeNr><kuvatavNr>(2)</kuvatavNr>
+              <tavatekst>Teine loige.</tavatekst></loige>
+            <loige><loigeNr ylaIndeks="1">2</loigeNr><kuvatavNr>(2¹)</kuvatavNr>
+              <tavatekst>Lõike kaks ülaindeks üks tekst.</tavatekst></loige>
+          </paragrahv>
+        </peatykk></sisu></akt>
+        """
+        root = ET.fromstring(xml)
+        alloc = generate_all_laws.PrefixAllocator(registry={})
+        doc = generate_all_laws.generate_law_jsonld(
+            "Test", "test_sup", root, abbreviation="TSUPX", allocator=alloc,
+        )
+        subs = {s["@id"]: s for s in _subsection_nodes(doc["@graph"])}
+        assert "estleg:TSUPX_Par_14_Lg_2" in subs
+        assert "estleg:TSUPX_Par_14_Lg_2_1" in subs
+        assert subs["estleg:TSUPX_Par_14_Lg_2_1"]["estleg:subsectionNumber"] == "2¹"
+        # And both are listed on the provision, in order.
+        par14 = next(
+            n for n in doc["@graph"] if n.get("@id") == "estleg:TSUPX_Par_14"
+        )
+        assert par14["estleg:hasSubsection"] == [
+            {"@id": "estleg:TSUPX_Par_14_Lg_2"},
+            {"@id": "estleg:TSUPX_Par_14_Lg_2_1"},
+        ]
+
+    def test_parent_provision_resolves_to_a_real_provision(self):
+        """Every Subsection's estleg:parentProvision equals an actual
+        LegalProvision @id in the same graph — no dangling refs."""
+        doc = self._three_loige_law()
+        provision_ids = {
+            n["@id"]
+            for n in doc["@graph"]
+            if isinstance(n, dict)
+            and isinstance(n.get("@type"), list)
+            and any(t.startswith("estleg:LegalProvision") for t in n["@type"] if isinstance(t, str))
+        }
+        assert provision_ids  # sanity
+        for s in _subsection_nodes(doc["@graph"]):
+            assert s["estleg:parentProvision"]["@id"] in provision_ids
+
+    def test_empty_loige_does_not_emit_a_subsection(self):
+        """A lõige with no text fragments (e.g. a repealed placeholder)
+        is skipped — no Subsection node, and it is absent from
+        estleg:hasSubsection. SHACL requires estleg:legalText, so an
+        empty Subsection would be invalid."""
+        xml = """
+        <akt><sisu><peatykk>
+          <peatykkNr>1</peatykkNr><peatykkPealkiri>P</peatykkPealkiri>
+          <paragrahv>
+            <paragrahvNr>7</paragrahvNr><kuvatavNr>§ 7. </kuvatavNr>
+            <paragrahvPealkiri>T</paragrahvPealkiri>
+            <loige><loigeNr>1</loigeNr><kuvatavNr>(1)</kuvatavNr>
+              <tavatekst>Esimene loige on olemas.</tavatekst></loige>
+            <loige><loigeNr>2</loigeNr><kuvatavNr>(2)</kuvatavNr></loige>
+            <loige><loigeNr>3</loigeNr><kuvatavNr>(3)</kuvatavNr>
+              <tavatekst>Kolmas loige on ka olemas.</tavatekst></loige>
+          </paragrahv>
+        </peatykk></sisu></akt>
+        """
+        root = ET.fromstring(xml)
+        alloc = generate_all_laws.PrefixAllocator(registry={})
+        doc = generate_all_laws.generate_law_jsonld(
+            "Test", "test_empty", root, abbreviation="TEMPX", allocator=alloc,
+        )
+        sub_ids = [s["@id"] for s in _subsection_nodes(doc["@graph"])]
+        assert sub_ids == ["estleg:TEMPX_Par_7_Lg_1", "estleg:TEMPX_Par_7_Lg_3"]
+        par7 = next(
+            n for n in doc["@graph"] if n.get("@id") == "estleg:TEMPX_Par_7"
+        )
+        assert par7["estleg:hasSubsection"] == [
+            {"@id": "estleg:TEMPX_Par_7_Lg_1"},
+            {"@id": "estleg:TEMPX_Par_7_Lg_3"},
+        ]
+
+    def test_subsection_ids_unique_within_a_law(self):
+        """All Subsection @ids in one law file are distinct (the
+        generator asserts this; a collision raises ValueError)."""
+        doc = self._three_loige_law()
+        sub_ids = [s["@id"] for s in _subsection_nodes(doc["@graph"])]
+        assert len(sub_ids) == len(set(sub_ids))
+
+    def test_duplicate_subsection_iri_raises(self):
+        """If the source XML produces two lõiked with the same canonical
+        IRI suffix (malformed input), the generator fails fast."""
+        # Two lõiked both resolving to suffix "2": one plain loigeNr=2,
+        # one loigeNr=2 again (no ylaIndeks) — same id.
+        xml = """
+        <akt><sisu><peatykk>
+          <peatykkNr>1</peatykkNr><peatykkPealkiri>P</peatykkPealkiri>
+          <paragrahv>
+            <paragrahvNr>1</paragrahvNr><kuvatavNr>§ 1. </kuvatavNr>
+            <paragrahvPealkiri>T</paragrahvPealkiri>
+            <loige><loigeNr>2</loigeNr><kuvatavNr>(2)</kuvatavNr>
+              <tavatekst>Esimene tekst.</tavatekst></loige>
+            <loige><loigeNr>2</loigeNr><kuvatavNr>(2)</kuvatavNr>
+              <tavatekst>Teine tekst.</tavatekst></loige>
+          </paragrahv>
+        </peatykk></sisu></akt>
+        """
+        root = ET.fromstring(xml)
+        alloc = generate_all_laws.PrefixAllocator(registry={})
+        with pytest.raises(ValueError):
+            generate_all_laws.generate_law_jsonld(
+                "Test", "test_dup", root, abbreviation="TDUPX", allocator=alloc,
+            )
+
+    def test_multipart_subsection_ids_are_osa_scoped(self):
+        """In a multipart law each Subsection IRI is namespaced by osa:
+        estleg:<PREFIX>_Osa<N>_Par_<n>_Lg_<m>; the parent provision link
+        points at the osa-scoped § IRI."""
+        xml = """
+        <akt><sisu>
+          <osa><osaNr>1</osaNr><osaPealkiri>Üldosa</osaPealkiri>
+            <paragrahv><paragrahvNr>5</paragrahvNr><kuvatavNr>§ 5. </kuvatavNr>
+              <paragrahvPealkiri>T</paragrahvPealkiri>
+              <loige><loigeNr>1</loigeNr><kuvatavNr>(1)</kuvatavNr>
+                <tavatekst>Esimene osa1 loige tekst.</tavatekst></loige>
+              <loige><loigeNr>2</loigeNr><kuvatavNr>(2)</kuvatavNr>
+                <tavatekst>Teine osa1 loige tekst.</tavatekst></loige>
+            </paragrahv>
+          </osa>
+          <osa><osaNr>2</osaNr><osaPealkiri>Eriosa</osaPealkiri>
+            <paragrahv><paragrahvNr>10</paragrahvNr><kuvatavNr>§ 10. </kuvatavNr>
+              <paragrahvPealkiri>T2</paragrahvPealkiri>
+              <loige><loigeNr>1</loigeNr><kuvatavNr>(1)</kuvatavNr>
+                <tavatekst>Osa2 loige tekst.</tavatekst></loige>
+            </paragrahv>
+          </osa>
+        </sisu></akt>
+        """
+        root = ET.fromstring(xml)
+        alloc = generate_all_laws.PrefixAllocator(registry={})
+        results = generate_all_laws.generate_multipart_law(
+            "Multi", "multi_test", root, abbreviation="MULTX", allocator=alloc,
+        )
+        by_file = dict(results)
+        osa1_subs = [s["@id"] for s in _subsection_nodes(by_file["multi_test_osa1_peep.json"]["@graph"])]
+        assert osa1_subs == [
+            "estleg:MULTX_Osa1_Par_5_Lg_1",
+            "estleg:MULTX_Osa1_Par_5_Lg_2",
+        ]
+        par5 = next(
+            n for n in by_file["multi_test_osa1_peep.json"]["@graph"]
+            if n.get("@id") == "estleg:MULTX_Osa1_Par_5"
+        )
+        assert par5["estleg:hasSubsection"] == [
+            {"@id": "estleg:MULTX_Osa1_Par_5_Lg_1"},
+            {"@id": "estleg:MULTX_Osa1_Par_5_Lg_2"},
+        ]
+        # Subsections of osa1 only point at osa1's provisions.
+        for s in _subsection_nodes(by_file["multi_test_osa1_peep.json"]["@graph"]):
+            assert s["estleg:parentProvision"]["@id"] == "estleg:MULTX_Osa1_Par_5"
+        osa2_subs = [s["@id"] for s in _subsection_nodes(by_file["multi_test_osa2_peep.json"]["@graph"])]
+        assert osa2_subs == ["estleg:MULTX_Osa2_Par_10_Lg_1"]
+
+
+class TestSubsectionHelpers:
+    """Unit coverage for the lõige-text and -number helpers."""
+
+    def test_loige_numbers_plain(self):
+        lg = ET.fromstring(
+            "<loige><loigeNr>2</loigeNr><kuvatavNr>(2)</kuvatavNr>"
+            "<tavatekst>x</tavatekst></loige>"
+        )
+        assert generate_all_laws._loige_numbers(lg) == ("2", "2")
+
+    def test_loige_numbers_ylaindeks(self):
+        lg = ET.fromstring(
+            "<loige><loigeNr ylaIndeks='1'>2</loigeNr><kuvatavNr>(2¹)</kuvatavNr>"
+            "<tavatekst>x</tavatekst></loige>"
+        )
+        assert generate_all_laws._loige_numbers(lg) == ("2¹", "2_1")
+
+    def test_loige_numbers_unicode_superscript_in_kuvatavnr(self):
+        # No ylaIndeks but kuvatavNr carries the superscript glyph.
+        lg = ET.fromstring(
+            "<loige><loigeNr>2</loigeNr><kuvatavNr>2²</kuvatavNr>"
+            "<tavatekst>x</tavatekst></loige>"
+        )
+        display, suffix = generate_all_laws._loige_numbers(lg)
+        assert display == "2²"
+        assert suffix == "2_2"
+
+    def test_loige_body_text_joins_and_filters(self):
+        lg = ET.fromstring(
+            "<loige><loigeNr>1</loigeNr>"
+            "<lause>Esimene lause.</lause><lause>ok</lause>"
+            "<tavatekst>Teine tekstiosa.</tavatekst></loige>"
+        )
+        # "ok" is <= 3 chars and is dropped.
+        assert generate_all_laws._loige_body_text(lg) == "Esimene lause. Teine tekstiosa."
+
+    def test_build_subsections_returns_empty_for_no_loige(self):
+        par = ET.fromstring(
+            "<paragrahv><paragrahvNr>1</paragrahvNr><kuvatavNr>§ 1.</kuvatavNr>"
+            "<tavatekst>Pole loiget.</tavatekst></paragrahv>"
+        )
+        assert generate_all_laws.build_subsections(
+            par, "estleg:X_Par_1", abbrev_prefix="X", par_suffix="1",
+            paragraph_display="§ 1.",
+        ) == []
+
+
+# ---------------------------------------------------------------------------
+# Issue #132 — vocabulary + SHACL coverage for the new Subsection model
+# ---------------------------------------------------------------------------
+
+
+class TestSubsectionVocabularyAndShapes:
+    """The new estleg:Subsection class and its properties are present and
+    correctly typed in the controlled vocabulary, and the SHACL shapes
+    file declares estleg:SubsectionShape plus the optional hasSubsection
+    property shape on LegalProvisionShape."""
+
+    def _vocab(self) -> dict:
+        path = (
+            generate_all_laws.REPO_ROOT
+            / "krr_outputs"
+            / "controlled_vocabulary.jsonld"
+        )
+        return json.loads(path.read_text(encoding="utf-8"))
+
+    def test_subsection_class_and_properties_defined_and_typed(self):
+        vocab = self._vocab()
+        by_id = {n["@id"]: n for n in vocab["@graph"] if isinstance(n, dict) and "@id" in n}
+        assert "owl:Class" in by_id["estleg:Subsection"]["@type"]
+        assert "owl:DatatypeProperty" in by_id["estleg:subsectionNumber"]["@type"]
+        assert by_id["estleg:subsectionNumber"]["rdfs:range"]["@id"] == "xsd:string"
+        assert "owl:ObjectProperty" in by_id["estleg:hasSubsection"]["@type"]
+        assert by_id["estleg:hasSubsection"]["rdfs:range"]["@id"] == "estleg:Subsection"
+        assert by_id["estleg:hasSubsection"]["owl:inverseOf"]["@id"] == "estleg:parentProvision"
+        assert "owl:ObjectProperty" in by_id["estleg:parentProvision"]["@type"]
+        assert by_id["estleg:parentProvision"]["rdfs:range"]["@id"] == "estleg:LegalProvision"
+        assert by_id["estleg:parentProvision"]["owl:inverseOf"]["@id"] == "estleg:hasSubsection"
+        # Every term carries a label and a comment.
+        for term in ("estleg:Subsection", "estleg:subsectionNumber",
+                     "estleg:hasSubsection", "estleg:parentProvision"):
+            assert by_id[term].get("rdfs:label")
+            assert by_id[term].get("rdfs:comment")
+
+    def test_shacl_declares_subsection_shape_and_property(self):
+        ttl = (
+            generate_all_laws.REPO_ROOT / "shacl" / "estonian_legal_shapes.ttl"
+        ).read_text(encoding="utf-8")
+        assert "estleg:SubsectionShape" in ttl
+        assert "sh:targetClass estleg:Subsection" in ttl
+        assert "estleg:subsectionNumber" in ttl
+        assert "estleg:parentProvision" in ttl
+        # hasSubsection is wired into LegalProvisionShape as an optional
+        # (minCount 0) IRI-valued property.
+        assert "estleg:hasSubsection" in ttl
+
+
+_CONTEXT = generate_all_laws.CONTEXT
+
+
+def _doc(*nodes: dict) -> dict:
+    return {"@context": _CONTEXT, "@graph": list(nodes)}
+
+
+def _well_formed_subsection() -> dict:
+    return {
+        "@id": "estleg:X_Par_14_Lg_2",
+        "@type": ["estleg:Subsection", "owl:NamedIndividual"],
+        "estleg:subsectionNumber": "2",
+        "estleg:legalText": "(2) Lõike kaks tekst.",
+        "estleg:parentProvision": {"@id": "estleg:X_Par_14"},
+        "rdfs:label": {"@value": "§ 14 lg 2", "@language": "et"},
+    }
+
+
+class TestSubsectionShaclConformance:
+    """#132: estleg:SubsectionShape accepts a well-formed Subsection and
+    rejects one missing subsectionNumber / legalText / parentProvision;
+    a LegalProvision with (and without) estleg:hasSubsection conforms."""
+
+    def test_well_formed_subsection_conforms(self):
+        ok, msg = _shacl_conforms(_doc(_well_formed_subsection()))
+        assert ok, msg
+
+    def test_subsection_without_label_conforms(self):
+        node = _well_formed_subsection()
+        del node["rdfs:label"]
+        ok, msg = _shacl_conforms(_doc(node))
+        assert ok, msg
+
+    def test_subsection_missing_number_rejected(self):
+        node = _well_formed_subsection()
+        del node["estleg:subsectionNumber"]
+        ok, _msg = _shacl_conforms(_doc(node))
+        assert not ok
+
+    def test_subsection_missing_legal_text_rejected(self):
+        node = _well_formed_subsection()
+        del node["estleg:legalText"]
+        ok, _msg = _shacl_conforms(_doc(node))
+        assert not ok
+
+    def test_subsection_missing_parent_provision_rejected(self):
+        node = _well_formed_subsection()
+        del node["estleg:parentProvision"]
+        ok, _msg = _shacl_conforms(_doc(node))
+        assert not ok
+
+    def test_subsection_parent_provision_literal_not_iri_rejected(self):
+        node = _well_formed_subsection()
+        node["estleg:parentProvision"] = {"@value": "estleg:X_Par_14"}
+        ok, _msg = _shacl_conforms(_doc(node))
+        assert not ok
+
+    def test_provision_with_has_subsection_still_conforms(self):
+        # estleg:summary on a provision is a plain (xsd:string) literal per
+        # estleg:LegalProvisionShape; mirror that here so the test isolates
+        # the optional estleg:hasSubsection property.
+        provision = {
+            "@id": "estleg:X_Par_14",
+            "@type": ["owl:NamedIndividual", "estleg:LegalProvision"],
+            "estleg:paragrahv": "§ 14",
+            "estleg:summary": "Teovõime.",
+            "estleg:legalText": "(2) Lõike kaks tekst.",
+            "estleg:hasSubsection": [{"@id": "estleg:X_Par_14_Lg_2"}],
+        }
+        ok, msg = _shacl_conforms(_doc(provision, _well_formed_subsection()))
+        assert ok, msg
+
+    def test_provision_without_has_subsection_still_conforms(self):
+        provision = {
+            "@id": "estleg:X_Par_15",
+            "@type": ["owl:NamedIndividual", "estleg:LegalProvision"],
+            "estleg:paragrahv": "§ 15",
+            "estleg:summary": "Üks lause.",
+            "estleg:legalText": "Üks lause vaid.",
+        }
+        ok, msg = _shacl_conforms(_doc(provision))
+        assert ok, msg


### PR DESCRIPTION
## Summary
`generate_all_laws.py` now emits, for every `paragrahv` with `loige` children, one `estleg:Subsection` named individual per lõige (`@id` `estleg:<ABBREV>_Par_<n>_Lg_<m>`, superscript-aware; `subsectionNumber`/`legalText`/`parentProvision`/`rdfs:label`); the § gets `estleg:hasSubsection` in document order. Punkt (item) level deferred → #203. New vocab (`estleg:Subsection`/`subsectionNumber`/`hasSubsection`/`parentProvision`); SHACL `SubsectionShape` + optional `hasSubsection` on `LegalProvisionShape`; combined regenerated; +24 tests.

**Not done — corpus regen:** `generate_all_laws.py` wasn't re-run against the committed peeps — they're out of sync with the current generator in three pre-existing ways (langString vs `xsd:string` on `summary`/`legalText`; multipart provision IRI scheme; enrichment layers the generator doesn't produce) → a naïve regen breaks gates. Filed as **#205** (corpus refresh + reconciliation, P2). The Subsection nodes materialise on the next generator run.

## Test plan
- [x] `pytest tests/` — 1,328 passed, 2 skipped
- [x] `ruff check scripts/ tests/` — clean
- [x] `python3 scripts/validate_all.py` — 0 errors / 1 benign warning; Internal Reference Integrity OK
- [x] `python3 scripts/validate_seadusloome_sync.py` — SHACL PASS
- [x] `python3 scripts/shacl_validate_all.py --bucket laws` — SHACL PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)