### PR TITLE
[codex] Harden PR 220 follow-up gates

### DIFF
--- a/docs/VALIDATION_REPORT.md
+++ b/docs/VALIDATION_REPORT.md
@@ -113,7 +113,9 @@ Similarity output now contains 71,421 analyzed provisions, 101,506 pairs, and up
 The #217 graph-closure pass removed a small set of `estleg:amendsLaw`
 targets from `krr_outputs/eelnoud/eelnoud_combined.jsonld` because the
 referenced act nodes are not emitted anywhere in the public load surface.
-These were not treated as successful resolutions:
+The table below is limited to dead-reference removals; successful target
+renames and array de-duplication are listed separately. These dead references
+were not treated as successful resolutions:
 
 | Removed target | Root cause |
 |----------------|------------|
@@ -125,6 +127,13 @@ These were not treated as successful resolutions:
 | `estleg:Isikuandmete_automatiseeritud__Map_2026` | Treaty `_Map_2026` target was inferred from a truncated title but no act-map node is emitted by the current pipeline. |
 | `estleg:Maailma_Terviseorganisatsiooni_Map_2026` | Treaty `_Map_2026` target was inferred from a title that no current generator materialises as an act-map node. |
 | `estleg:Merinuete_korral_vastutuse_pi_Map_2026` | Treaty `_Map_2026` target was inferred from a truncated title but no act-map node is emitted by the current pipeline. |
+
+Successful target rewrites in the same diff:
+
+| Removed target | Replacement target | Notes |
+|----------------|--------------------|-------|
+| `estleg:TKS_Map_2026` | `estleg:TarbKS_Map_2026` | Six references were rewritten to the emitted TarbKS map node. One duplicate-array entry on the draft "Ülikooliseaduse ja Tartu Ülikooli seaduse muutmise seadus" was removed without replacement because the array contained `TKS_Map_2026` twice. |
+| `estleg:TS_Map_2026` | `estleg:TõS_Map_2026` | Clean 1-to-1 rename to the emitted target. |
 
 Before the draft-impact enrichment is rerun against live data, fix the
 resolver path used by `scripts/extract_draft_impact.py` and

--- a/scripts/generate_all_laws.py
+++ b/scripts/generate_all_laws.py
@@ -1826,7 +1826,11 @@ def load_regen_state(path: Path | None) -> dict:
     try:
         with open(path, "r", encoding="utf-8") as f:
             state = json.load(f)
-    except (json.JSONDecodeError, OSError):
+    except (json.JSONDecodeError, OSError) as exc:
+        print(
+            f"WARNING: regen state {path} unreadable; starting fresh: {exc}",
+            file=sys.stderr,
+        )
         return {
             "schemaVersion": REGEN_STATE_SCHEMA_VERSION,
             "completed": {},

--- a/scripts/generate_court_decisions.py
+++ b/scripts/generate_court_decisions.py
@@ -26,8 +26,8 @@ Run with ``--fetch-full-text`` to enrich the existing
 then file order; ``0`` means *all* — a multi-hour ~12k-page scrape) it
 fetches the detail page and adds a plain-string ``estleg:legalText``
 literal to that decision node. Fetches are cached on disk under
-``krr_outputs/.cache/court_decisions/<safe_case_nr>.txt`` so reruns are
-near-instant and the full run is resumable. Decisions not fetched in a
+``krr_outputs/.cache/court_decisions/<safe_case_nr>_<digest>.txt`` so reruns
+are near-instant and the full run is resumable. Decisions not fetched in a
 given run keep their existing shape — ``estleg:legalText`` is optional.
 """
 
@@ -95,6 +95,7 @@ DETAIL_USER_AGENT = (
 # ``**/*.json{,ld}``, never ``.cache/`` or ``.txt``).
 COURT_TEXT_CACHE_DIR = KRR_DIR / ".cache" / "court_decisions"
 COURT_TEXT_CACHE_TTL_DAYS = 365  # decisions are immutable; refresh yearly
+_CACHE_DIGEST_SUFFIX_RE = re.compile(r"_[0-9a-f]{10}$")
 # Below this many characters the "decision text" is almost certainly the
 # search form or an error stub rather than a real decision body — treat
 # as a failed fetch and do not cache it.
@@ -749,6 +750,23 @@ def _court_text_cache_path(case_nr: str) -> Path:
     return COURT_TEXT_CACHE_DIR / f"{sanitize_id(case_nr)}_{digest}.txt"
 
 
+def _migrate_legacy_cache(cache_dir: Path) -> int:
+    """Delete pre-digest court full-text cache entries from ``cache_dir``."""
+    if not cache_dir.exists():
+        return 0
+    cleaned = 0
+    for path in cache_dir.glob("*.txt"):
+        if _CACHE_DIGEST_SUFFIX_RE.search(path.stem):
+            continue
+        try:
+            path.unlink()
+        except OSError as exc:
+            logger.warning("court cache cleanup: could not remove %s: %s", path, exc)
+        else:
+            cleaned += 1
+    return cleaned
+
+
 def _court_text_cache_is_fresh(
     path: Path, ttl_days: int = COURT_TEXT_CACHE_TTL_DAYS
 ) -> bool:
@@ -905,6 +923,10 @@ def enrich_full_text(limit: int = DEFAULT_FULL_TEXT_LIMIT, *, use_cache: bool = 
         "  Fetching full text for: "
         + ("all decisions (this is the multi-hour run)" if unbounded else f"up to {target}")
     )
+    if use_cache:
+        cleaned = _migrate_legacy_cache(COURT_TEXT_CACHE_DIR)
+        if cleaned:
+            print(f"cleaned {cleaned} legacy court cache entries")
     print(f"  Cache: {_rel_to_repo(COURT_TEXT_CACHE_DIR)} "
           f"({'enabled' if use_cache else 'BYPASSED'})")
 

--- a/tests/test_generate_all_laws.py
+++ b/tests/test_generate_all_laws.py
@@ -1435,6 +1435,22 @@ class TestRerunNoOpAndStaleRefresh:
 class TestRegenState:
     """#213: long subsection-regeneration runs can resume per law."""
 
+    def test_corrupt_regen_state_warns_and_resets(self, tmp_path, capsys):
+        state_path = tmp_path / "regen_state.json"
+        state_path.write_bytes(b"{not json")
+
+        state = generate_all_laws.load_regen_state(state_path)
+
+        captured = capsys.readouterr()
+        assert f"WARNING: regen state {state_path} unreadable; starting fresh" in (
+            captured.err
+        )
+        assert state == {
+            "schemaVersion": generate_all_laws.REGEN_STATE_SCHEMA_VERSION,
+            "completed": {},
+            "failed": {},
+        }
+
     def test_completed_laws_are_recorded_and_skipped_on_resume(
         self, tmp_path, monkeypatch
     ):

--- a/tests/test_generate_court_decisions.py
+++ b/tests/test_generate_court_decisions.py
@@ -478,6 +478,20 @@ def _isolated_court_cache(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Pa
 
 
 class TestFetchDecisionTextCache:
+    def test_legacy_cache_files_are_purged(self, tmp_path: Path) -> None:
+        cache_dir = tmp_path / "court_decisions"
+        cache_dir.mkdir()
+        legacy_plain = cache_dir / "321217652.txt"
+        legacy_underscored = cache_dir / "3_21_2176_52.txt"
+        current = cache_dir / "321217652_0123456789.txt"
+        for path in (legacy_plain, legacy_underscored, current):
+            path.write_text("cached", encoding="utf-8")
+
+        assert gcd._migrate_legacy_cache(cache_dir) == 2
+        assert not legacy_plain.exists()
+        assert not legacy_underscored.exists()
+        assert current.exists()
+
     def test_cache_hit_does_not_call_requests_get(
         self, _isolated_court_cache: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Summary

Implements the remaining Phase 1 follow-up items from the PR #220 roadmap after the 1.1 missing-parts tests were merged:

- purge legacy Riigikohus full-text cache files whose names predate the digest-suffixed cache key
- warn to stderr when a regen-state file is unreadable or corrupt before resetting to an empty state
- clarify `docs/VALIDATION_REPORT.md` so dead-reference removals are separated from successful target rewrites and array de-duplication

## Why

These are small operational hardening fixes before the deferred live ingestion work. The cache cleanup avoids avoidable refetches during the full Riigikohus run, the regen-state warning makes lost ledgers visible to operators, and the validation report now reflects what happened in the draft cleanup diff accurately.

## Validation

- `python3 -m ruff check scripts/ tests/`
- `python3 -m pytest -q tests/test_generate_court_decisions.py::TestFetchDecisionTextCache::test_legacy_cache_files_are_purged tests/test_generate_all_laws.py::TestRegenState::test_corrupt_regen_state_warns_and_resets`
- `python3 -m pytest -q` (`1462 passed, 2 skipped`)
- `python3 scripts/validate_all.py` (pass; expected missing manifest warning)
- `git diff --check`
